### PR TITLE
Ibeji Adapter Discovering Ibeji via Chariott

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ tokio-stream = { version = "0.1.8", features = ["net"] }
 tempfile = "3.5.0"
 futures = "0.3.28"
 prost = "0.11.9"
+service_discovery_proto = { git = "https://github.com/eclipse-chariott/chariott", branch = "main" }

--- a/digital_twin_adapters/ibeji_adapter/Cargo.toml
+++ b/digital_twin_adapters/ibeji_adapter/Cargo.toml
@@ -23,3 +23,6 @@ tempfile = { workspace = true }
 tower = { workspace = true }
 tokio-stream = { workspace = true }
 futures = { workspace = true }
+service_discovery_proto = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/digital_twin_adapters/ibeji_adapter/README.md
+++ b/digital_twin_adapters/ibeji_adapter/README.md
@@ -6,19 +6,52 @@ The Ibeji Adapter is used to integrate with [Eclipse-Ibeji's In-vehicle Digital 
 
 The adapter shares an `entity_map` map with Freyja's emitter that maps `entity_id`s to its entity info. When the emitter receives new mappings from the cartographer, it will update this shared state and insert `None` values for the corresponding ID. The adapter will detect empty entries for each `entity_id` in our `entity_map` then call `find_by_id` to send a request to [Ibeji's In-vehicle Digital Twin Service](https://github.com/eclipse-ibeji/ibeji), to populate the entity info.
 
-### Ibeji Registered as a Chariott Provider
+### Ibeji Without Chariott
 
-If Ibeji is registered in [Chariott's Service Discovery system](https://github.com/eclipse-chariott/chariott/tree/main/service_discovery), then please set the `invehicle_digital_twin_service_uri` field to `null` in the `res/config.json` file and set the `chariott_service_discovery_uri` field.
-
-Ibeji Adapter will discover Ibeji's In-Vehicle Digital Twin Service URI through Chariott.
+The Ibeji Adapter will use Ibeji's In-Vehicle Digital Digital URI if the `service_type` field in `res/config.json` is set to `"InVehicleDigitalTwinService`
 
 Example of config.json:
 
 ```json
 {
-    "invehicle_digital_twin_service_uri": null,
-    "chariott_service_discovery_uri": "http://0.0.0.0:50000"
+    "service_type": "InVehicleDigitalTwinService",
+    "uri": "http://0.0.0.0:5010"
 }
 ```
 
-If both the `invehicle_digital_twin_service_uri` and `chariott_service_discovery_uri` fields are set, then the Ibeji Adapter will directly contact the In-Vehicle Digital Twin Service URI and Chariott will not be used to discover the URI for the In-Vehicle Digital Twin Service.
+### Ibeji With Chariott
+
+If Ibeji is registered in [Chariott's Service Discovery system](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)and you wish to discover Ibeji through Chariott, then please set the `service type` field to `ChariottDiscoveryService` in the `res/config.json` file and set the value for the `uri` field.
+
+The Ibeji Adapter will discover Ibeji's In-Vehicle Digital Twin Service URI through Chariott.
+
+Example of config.json:
+
+```json
+{
+    "service_type": "ChariottDiscoveryService",
+    "uri": "http://0.0.0.0:50000"
+}
+```
+
+The example above will use a default namespace, name and version to discover Ibeji through Chariott.
+
+Default values in`config.rs` for sending a service discovery request to Chariott:
+
+- namespace = "sdv.ibeji",
+- name = "digital_twin",
+- version = "1.0"
+
+However, you can include an optional metadata field to specify the namespace, name and version for sending a service discovery request to Chariott:
+
+```json
+{
+    "service_type": "ChariottDiscoveryService",
+    "uri": "http://0.0.0.0:50000",
+    "metadata": {
+        "namespace": "sdv.ibeji",
+        "name": "digital_twin",
+        "version": "1.0"
+    }
+}
+```

--- a/digital_twin_adapters/ibeji_adapter/README.md
+++ b/digital_twin_adapters/ibeji_adapter/README.md
@@ -6,9 +6,11 @@ The Ibeji Adapter is used to integrate with [Eclipse-Ibeji's In-vehicle Digital 
 
 The adapter shares an `entity_map` map with Freyja's emitter that maps `entity_id`s to its entity info. When the emitter receives new mappings from the cartographer, it will update this shared state and insert `None` values for the corresponding ID. The adapter will detect empty entries for each `entity_id` in our `entity_map` then call `find_by_id` to send a request to [Ibeji's In-vehicle Digital Twin Service](https://github.com/eclipse-ibeji/ibeji), to populate the entity info.
 
-### Chariott Enabled with Ibeji
+### Ibeji Registered as a Chariott Provider
 
-If [Chariott's Service Discovery system](https://github.com/eclipse-chariott/chariott/tree/main/service_discovery) is enabled with Ibeji, then please set the `invehicle_digital_twin_service_uri` field to `null` in the `res/config.json` file.
+If Ibeji is registered in [Chariott's Service Discovery system](https://github.com/eclipse-chariott/chariott/tree/main/service_discovery), then please set the `invehicle_digital_twin_service_uri` field to `null` in the `res/config.json` file and set the `chariott_service_discovery_uri` field.
+
+Ibeji Adapter will discover Ibeji's In-Vehicle Digital Twin Service URI through Chariott.
 
 Example of config.json:
 

--- a/digital_twin_adapters/ibeji_adapter/README.md
+++ b/digital_twin_adapters/ibeji_adapter/README.md
@@ -21,28 +21,11 @@ Example of config.json:
 
 ### Ibeji With Chariott
 
-If Ibeji is registered in [Chariott's Service Discovery system](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)and you wish to discover Ibeji through Chariott, then please set the `service type` field to `ChariottDiscoveryService` in the `res/config.json` file and set the value for the `uri` field.
+If Ibeji is registered in [Chariott's Service Discovery system](https://github.com/eclipse-chariott/chariott/blob/main/service_discovery/README.md)and you wish to discover Ibeji through Chariott, then please set the `service type` field to `ChariottDiscoveryService` in the `res/config.json` file, value for the `uri` field, and the metadata for Ibeji.
 
 The Ibeji Adapter will discover Ibeji's In-Vehicle Digital Twin Service URI through Chariott.
 
 Example of config.json:
-
-```json
-{
-    "service_type": "ChariottDiscoveryService",
-    "uri": "http://0.0.0.0:50000"
-}
-```
-
-The example above will use a default namespace, name and version to discover Ibeji through Chariott.
-
-Default values in`config.rs` for sending a service discovery request to Chariott:
-
-- namespace = "sdv.ibeji",
-- name = "digital_twin",
-- version = "1.0"
-
-However, you can include an optional metadata field to specify the namespace, name and version for sending a service discovery request to Chariott:
 
 ```json
 {

--- a/digital_twin_adapters/ibeji_adapter/README.md
+++ b/digital_twin_adapters/ibeji_adapter/README.md
@@ -5,3 +5,18 @@ The Ibeji Adapter is used to integrate with [Eclipse-Ibeji's In-vehicle Digital 
 ## Behavior
 
 The adapter shares an `entity_map` map with Freyja's emitter that maps `entity_id`s to its entity info. When the emitter receives new mappings from the cartographer, it will update this shared state and insert `None` values for the corresponding ID. The adapter will detect empty entries for each `entity_id` in our `entity_map` then call `find_by_id` to send a request to [Ibeji's In-vehicle Digital Twin Service](https://github.com/eclipse-ibeji/ibeji), to populate the entity info.
+
+### Chariott Enabled with Ibeji
+
+If [Chariott's Service Discovery system](https://github.com/eclipse-chariott/chariott/tree/main/service_discovery) is enabled with Ibeji, then please set the `invehicle_digital_twin_service_uri` field to `null` in the `res/config.json` file.
+
+Example of config.json:
+
+```json
+{
+    "invehicle_digital_twin_service_uri": null,
+    "chariott_service_discovery_uri": "http://0.0.0.0:50000"
+}
+```
+
+If both the `invehicle_digital_twin_service_uri` and `chariott_service_discovery_uri` fields are set, then the Ibeji Adapter will directly contact the In-Vehicle Digital Twin Service URI and Chariott will not be used to discover the URI for the In-Vehicle Digital Twin Service.

--- a/digital_twin_adapters/ibeji_adapter/build.rs
+++ b/digital_twin_adapters/ibeji_adapter/build.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use std::{env, fs, path::Path};
+
+const OUT_DIR: &str = "OUT_DIR";
+const RESOURCE_DIR: &str = "res";
+const CONFIG_FILE: &str = "config.json";
+
+fn main() {
+    // Current directory of the build script is the package's root directory
+    let config_path = env::current_dir()
+        .unwrap()
+        .join(RESOURCE_DIR)
+        .join(CONFIG_FILE);
+
+    let target_dir = env::var(OUT_DIR).unwrap();
+    let dest_path = Path::new(&target_dir).join(CONFIG_FILE);
+
+    fs::copy(&config_path, dest_path).unwrap();
+
+    println!("cargo:rerun-if-changed={}", config_path.to_str().unwrap());
+}

--- a/digital_twin_adapters/ibeji_adapter/res/config.json
+++ b/digital_twin_adapters/ibeji_adapter/res/config.json
@@ -1,0 +1,4 @@
+{
+    "invehicle_digital_twin_service_uri": "http://0.0.0.0:5010",
+    "chariott_uri": null
+}

--- a/digital_twin_adapters/ibeji_adapter/res/config.json
+++ b/digital_twin_adapters/ibeji_adapter/res/config.json
@@ -1,4 +1,4 @@
 {
     "invehicle_digital_twin_service_uri": "http://0.0.0.0:5010",
-    "chariott_uri": null
+    "chariott_service_discovery_uri": "http://0.0.0.0:50000"
 }

--- a/digital_twin_adapters/ibeji_adapter/res/config.json
+++ b/digital_twin_adapters/ibeji_adapter/res/config.json
@@ -1,6 +1,6 @@
 {
     "service_type": "ChariottDiscoveryService",
-    "uri": "http://0.0.0.0:50000",
+    "uri": "http://0.0.0.0:5010",
     "metadata": {
         "namespace": "sdv.ibeji",
         "name": "digital_twin",

--- a/digital_twin_adapters/ibeji_adapter/res/config.json
+++ b/digital_twin_adapters/ibeji_adapter/res/config.json
@@ -1,4 +1,9 @@
 {
-    "invehicle_digital_twin_service_uri": "http://0.0.0.0:5010",
-    "chariott_service_discovery_uri": "http://0.0.0.0:50000"
+    "service_type": "ChariottDiscoveryService",
+    "uri": "http://0.0.0.0:50000",
+    "metadata": {
+        "namespace": "sdv.ibeji",
+        "name": "digital_twin",
+        "version": "1.0"
+    }
 }

--- a/digital_twin_adapters/ibeji_adapter/src/config.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/config.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) const CONFIG_FILE: &str = "config.json";
+
+/// Configuration settings for Ibeji Adapter
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Settings {
+    /// Ibeji's In-vehicle Digital Twin Service uri
+    /// If this uri is not null, then Chariott's Service Discovery uri is ignored
+    pub invehicle_digital_twin_service_uri: Option<String>,
+
+    /// Chariott's Service Discovery uri
+    pub chariott_service_discovery_uri: Option<String>,
+}

--- a/digital_twin_adapters/ibeji_adapter/src/config.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/config.rs
@@ -6,19 +6,39 @@ use serde::{Deserialize, Serialize};
 
 pub(crate) const CONFIG_FILE: &str = "config.json";
 
-/// Configuration settings for Ibeji Adapter
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Settings {
-    /// Ibeji's In-vehicle Digital Twin Service uri
-    /// If this uri is not null, then Chariott's Service Discovery uri is ignored
-    pub invehicle_digital_twin_service_uri: Option<String>,
+/// Configuration setting variants for selecting the service
+/// that the Ibeji Adapter should communicate with to interact with Ibeji
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "service_type")]
+pub enum Settings {
+    /// In-Vehicle Digital Twin Service
+    InVehicleDigitalTwinService { uri: String },
 
-    /// Chariott's Service Discovery uri
-    pub chariott_service_discovery_uri: Option<String>,
+    /// Chariott's Service Discovery to discover Ibeji
+    ChariottDiscoveryService {
+        uri: String,
+        metadata: Option<IbejiDiscoveryMetadata>,
+    },
 }
 
-pub(crate) mod chariott_ibeji_config {
-    pub const DIGITAL_TWIN_SERVICE_NAME: &str = "digital_twin";
-    pub const DIGITAL_TWIN_SERVICE_VERSION: &str = "1.0";
-    pub const CHARIOTT_NAMESPACE_FOR_IBEJI: &str = "sdv.ibeji";
+/// Configuration metadata for discovering Ibeji using Chariott
+#[derive(Clone, Serialize, Deserialize)]
+pub struct IbejiDiscoveryMetadata {
+    pub namespace: String,
+    pub name: String,
+    pub version: String,
+}
+
+impl Default for IbejiDiscoveryMetadata {
+    fn default() -> Self {
+        const CHARIOTT_NAMESPACE_FOR_IBEJI: &str = "sdv.ibeji";
+        const DIGITAL_TWIN_SERVICE_NAME: &str = "digital_twin";
+        const DIGITAL_TWIN_SERVICE_VERSION: &str = "1.0";
+
+        Self {
+            namespace: String::from(CHARIOTT_NAMESPACE_FOR_IBEJI),
+            name: String::from(DIGITAL_TWIN_SERVICE_NAME),
+            version: String::from(DIGITAL_TWIN_SERVICE_VERSION),
+        }
+    }
 }

--- a/digital_twin_adapters/ibeji_adapter/src/config.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/config.rs
@@ -16,3 +16,9 @@ pub struct Settings {
     /// Chariott's Service Discovery uri
     pub chariott_service_discovery_uri: Option<String>,
 }
+
+pub(crate) mod chariott_ibeji_config {
+    pub const DIGITAL_TWIN_SERVICE_NAME: &str = "digital_twin";
+    pub const DIGITAL_TWIN_SERVICE_VERSION: &str = "1.0";
+    pub const CHARIOTT_NAMESPACE_FOR_IBEJI: &str = "sdv.ibeji";
+}

--- a/digital_twin_adapters/ibeji_adapter/src/config.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/config.rs
@@ -17,7 +17,7 @@ pub enum Settings {
     /// Chariott's Service Discovery to discover Ibeji
     ChariottDiscoveryService {
         uri: String,
-        metadata: Option<IbejiDiscoveryMetadata>,
+        metadata: IbejiDiscoveryMetadata,
     },
 }
 
@@ -27,18 +27,4 @@ pub struct IbejiDiscoveryMetadata {
     pub namespace: String,
     pub name: String,
     pub version: String,
-}
-
-impl Default for IbejiDiscoveryMetadata {
-    fn default() -> Self {
-        const CHARIOTT_NAMESPACE_FOR_IBEJI: &str = "sdv.ibeji";
-        const DIGITAL_TWIN_SERVICE_NAME: &str = "digital_twin";
-        const DIGITAL_TWIN_SERVICE_VERSION: &str = "1.0";
-
-        Self {
-            namespace: String::from(CHARIOTT_NAMESPACE_FOR_IBEJI),
-            name: String::from(DIGITAL_TWIN_SERVICE_NAME),
-            version: String::from(DIGITAL_TWIN_SERVICE_VERSION),
-        }
-    }
 }

--- a/digital_twin_adapters/ibeji_adapter/src/ibeji_adapter.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/ibeji_adapter.rs
@@ -105,15 +105,13 @@ impl IbejiAdapter {
     /// - `metadata`: optional configuration metadata for discovering Ibeji using Chariott
     async fn retrieve_ibeji_invehicle_digital_twin_uri_from_chariott(
         chariott_service_discovery_uri: &str,
-        metadata: Option<IbejiDiscoveryMetadata>,
+        chariott_ibeji_config: IbejiDiscoveryMetadata,
     ) -> Result<String, DigitalTwinAdapterError> {
         let mut service_registry_client =
             ServiceRegistryClient::connect(String::from(chariott_service_discovery_uri))
                 .await
                 .map_err(DigitalTwinAdapterError::communication)?;
 
-        // If the metadata is None then the default function for IbejiDiscoveryMetadata is called.
-        let chariott_ibeji_config = metadata.unwrap_or_default();
         let discover_request = Request::new(DiscoverRequest {
             namespace: chariott_ibeji_config.namespace,
             name: chariott_ibeji_config.name,

--- a/digital_twin_adapters/ibeji_adapter/src/ibeji_adapter.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/ibeji_adapter.rs
@@ -102,7 +102,7 @@ impl IbejiAdapter {
     ///
     /// # Arguments
     /// - `chariott_service_discovery_uri`: the uri for Chariott's service discovery
-    /// - `metadata`: the configuration metadata needed to discover Ibeji using Chariott
+    /// - `metadata`: optional configuration metadata for discovering Ibeji using Chariott
     async fn retrieve_ibeji_invehicle_digital_twin_uri_from_chariott(
         chariott_service_discovery_uri: &str,
         metadata: Option<IbejiDiscoveryMetadata>,
@@ -112,6 +112,7 @@ impl IbejiAdapter {
                 .await
                 .map_err(DigitalTwinAdapterError::communication)?;
 
+        // If the metadata is None then the default function for IbejiDiscoveryMetadata is called.
         let chariott_ibeji_config = metadata.unwrap_or_default();
         let discover_request = Request::new(DiscoverRequest {
             namespace: chariott_ibeji_config.namespace,

--- a/digital_twin_adapters/ibeji_adapter/src/lib.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/lib.rs
@@ -3,5 +3,6 @@
 // SPDX-License-Identifier: MIT
 
 pub mod ibeji_adapter;
+mod config;
 
 pub use crate::ibeji_adapter::IbejiAdapter as DigitalTwinAdapterImpl;

--- a/digital_twin_adapters/ibeji_adapter/src/lib.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-pub mod ibeji_adapter;
 mod config;
+pub mod ibeji_adapter;
 
 pub use crate::ibeji_adapter::IbejiAdapter as DigitalTwinAdapterImpl;


### PR DESCRIPTION
Freyja's Ibeji Adapter uses the new service discovery mechanism that Chariott provides to discover Ibeji's In-Vehicle Digital Twin Service URI.