### PR TITLE
Consolidate identical code in digital twin adapters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,16 @@ members = [
 ]
 
 [workspace.dependencies]
+# Freyja dependencies
+dts-contracts = { path = "contracts" }
+mock-digital-twin = { path = "mocks/mock_digital_twin" }
+
+# Other SDV projects
+core-protobuf-data-access = { git = "https://github.com/eclipse-ibeji/ibeji", branch = "main" }
+samples-protobuf-data-access = { git = "https://github.com/eclipse-ibeji/ibeji", branch = "main" }
+service_discovery_proto = { git = "https://github.com/eclipse-chariott/chariott", branch = "main" }
+
+# crates.io dependencies
 async-trait = "0.1.64"
 axum = "0.6.12"
 convert_case = "0.6.0"
@@ -48,7 +58,3 @@ tokio-stream = { version = "0.1.8", features = ["net"] }
 tonic = "0.9.2"
 tonic-build = "0.9.2"
 tower = { version = "0.4", features = ["util"] }
-
-core-protobuf-data-access = { git = "https://github.com/eclipse-ibeji/ibeji", branch = "main" }
-samples-protobuf-data-access = { git = "https://github.com/eclipse-ibeji/ibeji", branch = "main" }
-service_discovery_proto = { git = "https://github.com/eclipse-chariott/chariott", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,31 +22,32 @@ members = [
 ]
 
 [workspace.dependencies]
-async-trait = { version = "0.1.64" }
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "time", "sync", "test-util"] }
+async-trait = "0.1.64"
+axum = "0.6.12"
+convert_case = "0.6.0"
+core-protobuf-data-access  = { git = "https://github.com/eclipse-ibeji/ibeji",  branch = "main" }
+crossbeam = "0.8.2"
+env_logger = "0.10.0"
+futures = "0.3.28"
+httptest = "0.15.4"
 log = "^0.4"
+paho-mqtt = "0.12"
+proc-macro2 = "1.0.52"
+prost = "0.11.9"
+quote = "1.0.23"
+reqwest = { version = "0.11.4", features = ["json"] }
+rstest = "0.18.1"
+samples-protobuf-data-access  = { git = "https://github.com/eclipse-ibeji/ibeji",  branch = "main" }
 serde = { version = "1.0.88", features = ["derive"] }
 serde_json = "1.0.88"
-env_logger = "0.10.0"
-convert_case = "0.6.0"
-proc-macro2 = "1.0.52"
-quote = "1.0.23"
+service_discovery_proto = { git = "https://github.com/eclipse-chariott/chariott", branch = "main" }
+strum = "0.25.0"
+strum_macros = "0.25.1"
 syn = { version = "2.0.8", features = ["extra-traits", "full"] }
-axum = "0.6.12"
+tempfile = "3.5.0"
 time = "0.3.20"
-reqwest = { version = "0.11.4", features = ["json"] }
-httptest = "0.15.4"
-tower = { version = "0.4", features = ["util"] }
-strum = "0.24"
-strum_macros = "0.24"
-core-protobuf-data-access  = { git = "https://github.com/eclipse-ibeji/ibeji",  branch = "main" }
-samples-protobuf-data-access  = { git = "https://github.com/eclipse-ibeji/ibeji",  branch = "main" }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "time", "sync", "test-util"] }
+tokio-stream = { version = "0.1.8", features = ["net"] }
 tonic = "0.9.2"
 tonic-build = "0.9.2"
-crossbeam = "0.8.2"
-tokio-stream = { version = "0.1.8", features = ["net"] }
-tempfile = "3.5.0"
-futures = "0.3.28"
-prost = "0.11.9"
-service_discovery_proto = { git = "https://github.com/eclipse-chariott/chariott", branch = "main" }
-paho-mqtt = "0.12"
+tower = { version = "0.4", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ members = [
 async-trait = "0.1.64"
 axum = "0.6.12"
 convert_case = "0.6.0"
-core-protobuf-data-access  = { git = "https://github.com/eclipse-ibeji/ibeji",  branch = "main" }
 crossbeam = "0.8.2"
 env_logger = "0.10.0"
 futures = "0.3.28"
@@ -37,10 +36,8 @@ prost = "0.11.9"
 quote = "1.0.23"
 reqwest = { version = "0.11.4", features = ["json"] }
 rstest = "0.18.1"
-samples-protobuf-data-access  = { git = "https://github.com/eclipse-ibeji/ibeji",  branch = "main" }
 serde = { version = "1.0.88", features = ["derive"] }
 serde_json = "1.0.88"
-service_discovery_proto = { git = "https://github.com/eclipse-chariott/chariott", branch = "main" }
 strum = "0.25.0"
 strum_macros = "0.25.1"
 syn = { version = "2.0.8", features = ["extra-traits", "full"] }
@@ -51,3 +48,7 @@ tokio-stream = { version = "0.1.8", features = ["net"] }
 tonic = "0.9.2"
 tonic-build = "0.9.2"
 tower = { version = "0.4", features = ["util"] }
+
+core-protobuf-data-access = { git = "https://github.com/eclipse-ibeji/ibeji", branch = "main" }
+samples-protobuf-data-access = { git = "https://github.com/eclipse-ibeji/ibeji", branch = "main" }
+service_discovery_proto = { git = "https://github.com/eclipse-chariott/chariott", branch = "main" }

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -18,3 +18,6 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -11,9 +11,10 @@ license = "MIT"
 [dependencies]
 proc-macros = { path = "../proc_macros" }
 async-trait = { workspace = true }
-tokio = { workspace = true }
+crossbeam = { workspace = true }
+log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-crossbeam = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+tokio = { workspace = true }

--- a/contracts/src/digital_twin_adapter.rs
+++ b/contracts/src/digital_twin_adapter.rs
@@ -48,7 +48,7 @@ pub trait DigitalTwinAdapter {
         provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
     ) -> Result<(), DigitalTwinAdapterError>;
 
-    /// Updates a shared entity map to populate empty values with provider information fetched from the digital twim service.
+    /// Updates a shared entity map to populate empty values with provider information fetched from the digital twin service.
     /// This default implementation is shared for all providers.
     ///
     /// # Arguments

--- a/contracts/src/digital_twin_adapter.rs
+++ b/contracts/src/digital_twin_adapter.rs
@@ -199,19 +199,16 @@ mod digital_twin_adapter_tests {
     }
 
     #[fixture]
-    fn fixture(
-        #[default(
-            Entity {
-                id: "entity_id".to_string(),
-                name: Some("name".to_string()),
-                uri: "uri".to_string(),
-                description: Some("description".to_string()),
-                operation: OperationKind::Get,
-                protocol: "protocol".to_string(),
-            }
-        )]
-        entity: Entity,
-    ) -> TestFixture {
+    fn fixture() -> TestFixture {
+        let entity = Entity {
+            id: "entity_id".to_string(),
+            name: Some("name".to_string()),
+            uri: "uri".to_string(),
+            description: Some("description".to_string()),
+            operation: OperationKind::Get,
+            protocol: "protocol".to_string(),
+        };
+
         let (sender, mut receiver) = 
             mpsc::unbounded_channel::<ProviderProxySelectorRequestKind>();
         
@@ -292,4 +289,6 @@ mod digital_twin_adapter_tests {
         let proxy_request = join_result.unwrap();
         assert!(proxy_request.is_none());
     }
+
+    // TODO: test provider not found case
 }

--- a/contracts/src/digital_twin_adapter.rs
+++ b/contracts/src/digital_twin_adapter.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     entity::{Entity, EntityID},
-    provider_proxy_request::ProviderProxySelectorRequestSender,
+    provider_proxy_request::{ProviderProxySelectorRequestSender, ProviderProxySelectorRequestKind},
 };
 
 /// Provides digital twin data
@@ -45,6 +45,59 @@ pub trait DigitalTwinAdapter {
         sleep_interval: Duration,
         provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
     ) -> Result<(), DigitalTwinAdapterError>;
+
+    /// Updates a shared entity map to populate empty values with provider information.
+    /// This default implementation is shared for all providers.
+    /// 
+    /// # Arguments
+    /// - `entity_map`: the map to update
+    /// - `provider_proxy_selector_request_sender`: sends requests to the provider proxy selector
+    async fn update_entity_map(
+        &self,
+        entity_map: Arc<Mutex<HashMap<EntityID, Option<Entity>>>>,
+        provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
+    ) -> Result<(), DigitalTwinAdapterError> 
+    where
+        Self: Sized
+    {
+        let mut updated_entities = { 
+            let map = entity_map.lock().unwrap();
+            map.clone()
+        };
+
+        // Update any entries which don't have an entity yet
+        for (entity_id, entity) in updated_entities.iter_mut().filter(|(_, e)| e.is_none()) {
+            let request = GetDigitalTwinProviderRequest {
+                entity_id: entity_id.clone(),
+            };
+
+            match self.find_by_id(request).await {
+                Ok(response) => {
+                    *entity = Some(response.entity.clone());
+
+                    // Notify the provider proxy selector to start a proxy
+                    let Entity { id, uri, operation, protocol, .. } = response.entity;
+                    let request = ProviderProxySelectorRequestKind::CreateOrUpdateProviderProxy(
+                        id, uri, protocol, operation,
+                    );
+
+                    provider_proxy_selector_request_sender
+                        .send_request_to_provider_proxy_selector(request);
+                }
+                Err(err) => {
+                    log::error!("{err}");
+                }
+            };
+        }
+
+        // Update the shared map
+        {
+            let mut map = entity_map.lock().unwrap();
+            *map = updated_entities;
+        }
+
+        Ok(())
+    }
 }
 
 /// A request for digital twin providers
@@ -90,5 +143,141 @@ proc_macros::error! {
         Communication,
         ParseError,
         Unknown
+    }
+}
+
+#[cfg(test)]
+mod digital_twin_adapter_tests {
+    use crate::provider_proxy::OperationKind;
+
+    use super::*;
+
+    use tokio::sync::mpsc;
+    
+    fn get_test_entity(id: &String) -> Entity
+    {
+        Entity { 
+            id: id.clone(), 
+            name: Some("name".to_string()), 
+            uri: "uri".to_string(), 
+            description: Some("description".to_string()), 
+            operation: OperationKind::Get,
+            protocol: "protocol".to_string(),
+        } 
+    }
+
+    struct TestDigitalTwinAdapter {}
+
+    #[async_trait]
+    impl DigitalTwinAdapter for TestDigitalTwinAdapter {
+        fn create_new() -> Result<Box<dyn DigitalTwinAdapter + Send + Sync>, DigitalTwinAdapterError> {
+            Ok(Box::new(Self {}))
+        }
+
+        async fn find_by_id(
+            &self,
+            request: GetDigitalTwinProviderRequest,
+        ) -> Result<GetDigitalTwinProviderResponse, DigitalTwinAdapterError> {
+            Ok(GetDigitalTwinProviderResponse { 
+                entity: get_test_entity(&request.entity_id),
+            })
+        }
+
+        async fn run(
+            &self,
+            _entity_map: Arc<Mutex<HashMap<EntityID, Option<Entity>>>>,
+            _sleep_interval: Duration,
+            _provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
+        ) -> Result<(), DigitalTwinAdapterError> {
+            Err(DigitalTwinAdapterError::unknown("not implemented"))
+        }
+    }
+
+    #[tokio::test]
+    async fn update_entity_map_updates_none_value() {
+        // Setup
+        let id = String::from("id");
+        let mut entites: HashMap<EntityID, Option<Entity>> = HashMap::new();
+        entites.insert(id.clone(), None);
+        let shared_map = Arc::new(Mutex::new(entites));
+
+        let (sender, mut receiver) =
+            mpsc::unbounded_channel::<ProviderProxySelectorRequestKind>();
+        let ppsrs = ProviderProxySelectorRequestSender::new(sender);
+
+        let data_received: Arc<Mutex<Option<ProviderProxySelectorRequestKind>>> = Arc::new(Mutex::new(None));
+        let data_received_clone = data_received.clone();
+
+        let listener = tokio::spawn(async move {
+            let value = receiver.recv().await;
+            let mut data = data_received_clone.lock().unwrap();
+            *data = value;
+        });
+        
+        let uut = TestDigitalTwinAdapter {};
+
+        // Test
+        let update_result = uut.update_entity_map(shared_map.clone(), Arc::new(ppsrs)).await;
+        let join_result = listener.await;
+
+        // Verify
+        assert!(update_result.is_ok());
+        assert!(join_result.is_ok());
+
+        let guard = shared_map.lock().unwrap();
+        let value = guard.get(&id);
+        assert!(value.is_some());
+        assert!(value.unwrap().is_some());
+        let entity = value.unwrap().as_ref().unwrap();
+        assert_eq!(entity.id, id);
+
+        let data = data_received.lock().unwrap();
+        assert!(data.is_some());
+        match data.as_ref().unwrap() {
+            ProviderProxySelectorRequestKind::CreateOrUpdateProviderProxy(entity_id, _, _, _) => assert_eq!(*entity_id, id),
+            _ => assert!(false),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_entity_map_ignores_some_value() {
+        // Setup
+        let id = String::from("id");
+        let mut entites: HashMap<EntityID, Option<Entity>> = HashMap::new();
+        entites.insert(id.clone(), Some(get_test_entity(&id)));
+        let shared_map = Arc::new(Mutex::new(entites));
+
+        let (sender, mut receiver) =
+            mpsc::unbounded_channel::<ProviderProxySelectorRequestKind>();
+        let ppsrs = ProviderProxySelectorRequestSender::new(sender);
+
+        let data_received: Arc<Mutex<Option<ProviderProxySelectorRequestKind>>> = Arc::new(Mutex::new(None));
+        let data_received_clone = data_received.clone();
+
+        let listener = tokio::spawn(async move {
+            let value = receiver.recv().await;
+            let mut data = data_received_clone.lock().unwrap();
+            *data = value;
+        });
+        
+        let uut = TestDigitalTwinAdapter {};
+
+        // Test
+        let update_result = uut.update_entity_map(shared_map.clone(), Arc::new(ppsrs)).await;
+        let join_result = listener.await;
+
+        // Verify
+        assert!(update_result.is_ok());
+        assert!(join_result.is_ok());
+
+        let guard = shared_map.lock().unwrap();
+        let value = guard.get(&id);
+        assert!(value.is_some());
+        assert!(value.unwrap().is_some());
+        let entity = value.unwrap().as_ref().unwrap();
+        assert_eq!(entity.id, id);
+
+        let data = data_received.lock().unwrap();
+        assert!(data.is_none());
     }
 }

--- a/contracts/src/digital_twin_adapter.rs
+++ b/contracts/src/digital_twin_adapter.rs
@@ -48,7 +48,7 @@ pub trait DigitalTwinAdapter {
 
     /// Updates a shared entity map to populate empty values with provider information fetched from the digital twim service.
     /// This default implementation is shared for all providers.
-    /// 
+    ///
     /// # Arguments
     /// - `entity_map`: the map to update
     /// - `provider_proxy_selector_request_sender`: sends requests to the provider proxy selector
@@ -56,12 +56,12 @@ pub trait DigitalTwinAdapter {
         &self,
         entity_map: Arc<Mutex<HashMap<EntityID, Option<Entity>>>>,
         provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
-    ) -> Result<(), DigitalTwinAdapterError> 
+    ) -> Result<(), DigitalTwinAdapterError>
     where
         Self: Sized
     {
         // Copy the shared map
-        let mut updated_entities = { 
+        let mut updated_entities = {
             let map = entity_map.lock().unwrap();
             map.clone()
         };
@@ -150,7 +150,7 @@ proc_macros::error! {
 #[cfg(test)]
 mod digital_twin_adapter_tests {
     use super::*;
-    
+
     use crate::provider_proxy::OperationKind;
 
     use rstest::*;
@@ -171,7 +171,7 @@ mod digital_twin_adapter_tests {
             request: GetDigitalTwinProviderRequest,
         ) -> Result<GetDigitalTwinProviderResponse, DigitalTwinAdapterError> {
             if self.entity.id == request.entity_id {
-                Ok(GetDigitalTwinProviderResponse { 
+                Ok(GetDigitalTwinProviderResponse {
                     entity: self.entity.clone(),
                 })
             } else {
@@ -209,9 +209,9 @@ mod digital_twin_adapter_tests {
             protocol: "protocol".to_string(),
         };
 
-        let (sender, mut receiver) = 
+        let (sender, mut receiver) =
             mpsc::unbounded_channel::<ProviderProxySelectorRequestKind>();
-        
+
         let listener_handler = tokio::spawn(async move {
             receiver.recv().await
         });
@@ -230,10 +230,9 @@ mod digital_twin_adapter_tests {
         let map = map.lock().unwrap();
         let value = map.get(&entity.id);
         assert!(value.is_some());
-        println!("{:?}", value.unwrap());
         assert!(value.unwrap().is_some());
-        let entity = value.unwrap().as_ref().unwrap();
-        assert_eq!(entity.id, entity.id);
+        let retrieved_entity = value.unwrap().as_ref().unwrap();
+        assert_eq!(entity.id, retrieved_entity.id);
     }
 
     #[rstest]
@@ -259,9 +258,10 @@ mod digital_twin_adapter_tests {
 
         let proxy_request = join_result.unwrap();
         assert!(proxy_request.is_some());
-        match proxy_request.as_ref().unwrap() {
+        let proxy_request = proxy_request.as_ref().unwrap();
+        match proxy_request {
             ProviderProxySelectorRequestKind::CreateOrUpdateProviderProxy(entity_id, _, _, _) => assert_eq!(*entity_id, fixture.entity_id),
-            _ => assert!(false),
+            _ => panic!("Unexpected proxy request kind: {proxy_request:?}"),
         }
     }
 
@@ -285,7 +285,7 @@ mod digital_twin_adapter_tests {
         assert!(join_result.is_ok());
 
         assert_entity_is_in_map(fixture.entity, fixture.map.clone());
-        
+
         let proxy_request = join_result.unwrap();
         assert!(proxy_request.is_none());
     }

--- a/contracts/src/digital_twin_adapter.rs
+++ b/contracts/src/digital_twin_adapter.rs
@@ -269,13 +269,18 @@ mod digital_twin_adapter_tests {
         assert!(update_result.is_ok());
         assert!(join_result.is_ok());
 
-        assert_entity_is_in_map(fixture.entity, fixture.map.clone());
+        assert_entity_is_in_map(fixture.entity.clone(), fixture.map.clone());
 
         let proxy_request = join_result.unwrap();
         assert!(proxy_request.is_some());
         let proxy_request = proxy_request.as_ref().unwrap();
         match proxy_request {
-            ProviderProxySelectorRequestKind::CreateOrUpdateProviderProxy(entity_id, _, _, _) => assert_eq!(*entity_id, fixture.entity_id),
+            ProviderProxySelectorRequestKind::CreateOrUpdateProviderProxy(entity_id, uri, protocol, operation) => {
+                assert_eq!(*entity_id, fixture.entity_id);
+                assert_eq!(*uri, fixture.entity.uri);
+                assert_eq!(*protocol, fixture.entity.protocol);
+                assert_eq!(*operation, fixture.entity.operation);
+            }
             _ => panic!("Unexpected proxy request kind: {proxy_request:?}"),
         }
     }

--- a/contracts/src/entity.rs
+++ b/contracts/src/entity.rs
@@ -10,7 +10,7 @@ pub type EntityID = String;
 pub type ProviderURI = String;
 
 /// Represents an entity
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Entity {
     /// The entity's id
     pub id: String,

--- a/contracts/src/provider_proxy.rs
+++ b/contracts/src/provider_proxy.rs
@@ -9,7 +9,7 @@ use crossbeam::queue::SegQueue;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
-#[derive(Debug, EnumString, Display, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, EnumString, Display, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[strum(ascii_case_insensitive)]
 pub enum OperationKind {
     #[strum(serialize = "Get")]

--- a/digital_twin_adapters/ibeji_adapter/src/ibeji_adapter.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/ibeji_adapter.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use core_protobuf_data_access::digital_twin::v1::{
     digital_twin_client::DigitalTwinClient, EndpointInfo, FindByIdRequest,
 };
-use log::{debug, error, warn};
+use log::{debug, warn};
 use service_discovery_proto::service_registry::v1::service_registry_client::ServiceRegistryClient;
 use service_discovery_proto::service_registry::v1::DiscoverRequest;
 use tonic::{transport::Channel, Request};
@@ -28,9 +28,7 @@ use dts_contracts::{
     },
     entity::{Entity, EntityID},
     provider_proxy::OperationKind,
-    provider_proxy_request::{
-        ProviderProxySelectorRequestKind, ProviderProxySelectorRequestSender,
-    },
+    provider_proxy_request:: ProviderProxySelectorRequestSender,
 };
 
 const GET_OPERATION: &str = "Get";
@@ -42,62 +40,6 @@ pub struct IbejiAdapter {
 }
 
 impl IbejiAdapter {
-    /// Creates or updates a provider proxy for each entity using its info then caches the info in entity_map
-    ///
-    /// # Arguments
-    /// - `entity_map`: shared map of entity ID to entity information
-    /// - `provider_proxy_selector_request_sender`: sends requests to the provider proxy selector
-    async fn init_provider_proxies_with_entities(
-        &self,
-        entity_map: Arc<Mutex<HashMap<EntityID, Option<Entity>>>>,
-        provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
-    ) -> Result<(), DigitalTwinAdapterError> {
-        let mut entity_map_update;
-        {
-            entity_map_update = entity_map.lock().unwrap().clone();
-        }
-
-        // Update the copy of entity map if it contains an entity that has no information
-        for (entity_id, entity) in entity_map_update.iter_mut() {
-            if entity.is_some() {
-                continue;
-            }
-
-            // Update the copy of entity map if we're able to find the info of an entity after doing find_by_id
-            let request = GetDigitalTwinProviderRequest {
-                entity_id: entity_id.clone(),
-            };
-
-            match self.find_by_id(request).await {
-                Ok(response) => {
-                    let entity_info = response.entity.clone();
-                    let (id, uri, protocol, operation) = (
-                        entity_info.id,
-                        entity_info.uri,
-                        entity_info.protocol,
-                        entity_info.operation,
-                    );
-                    *entity = Some(response.entity);
-
-                    // Notify the provider proxy selector to start a proxy
-                    let request = ProviderProxySelectorRequestKind::CreateOrUpdateProviderProxy(
-                        id, uri, protocol, operation,
-                    );
-                    provider_proxy_selector_request_sender
-                        .send_request_to_provider_proxy_selector(request);
-                }
-                Err(err) => {
-                    error!("{err}");
-                    *entity = None
-                }
-            };
-        }
-
-        *entity_map.lock().unwrap() = entity_map_update;
-
-        Ok(())
-    }
-
     /// Retrieves Ibeji's In-Vehicle Digital Twin URI from Chariott
     ///
     /// # Arguments
@@ -247,11 +189,7 @@ impl DigitalTwinAdapter for IbejiAdapter {
         provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
     ) -> Result<(), DigitalTwinAdapterError> {
         loop {
-            self.init_provider_proxies_with_entities(
-                entity_map.clone(),
-                provider_proxy_selector_request_sender.clone(),
-            )
-            .await?;
+            self.update_entity_map(entity_map.clone(),provider_proxy_selector_request_sender.clone()).await?;
             tokio::time::sleep(sleep_interval).await;
         }
     }
@@ -325,10 +263,7 @@ mod ibeji_digital_twin_adapter_tests {
 
         use core_protobuf_data_access::digital_twin::v1::digital_twin_server::DigitalTwinServer;
         use tempfile::TempPath;
-        use tokio::{
-            net::{UnixListener, UnixStream},
-            sync::mpsc,
-        };
+        use tokio::net::{UnixListener, UnixStream};
         use tokio_stream::wrappers::UnixListenerStream;
         use tonic::transport::{Channel, Endpoint, Server, Uri};
         use tower::service_fn;
@@ -353,49 +288,6 @@ mod ibeji_digital_twin_adapter_tests {
                 .serve_with_incoming(uds_stream)
                 .await
                 .unwrap();
-        }
-
-        #[tokio::test]
-        async fn init_provider_proxies_with_entities_test() {
-            // Create the Unix Socket
-            let bind_path = Arc::new(tempfile::NamedTempFile::new().unwrap().into_temp_path());
-            let uds = match UnixListener::bind(bind_path.as_ref()) {
-                Ok(unix_listener) => unix_listener,
-                Err(_) => {
-                    std::fs::remove_file(bind_path.as_ref()).unwrap();
-                    UnixListener::bind(bind_path.as_ref()).unwrap()
-                }
-            };
-            let uds_stream = UnixListenerStream::new(uds);
-
-            let request_future = async {
-                let client = create_test_grpc_client(bind_path.clone()).await;
-                let ibeji_digital_twin_adapter = IbejiAdapter { client };
-
-                let (tx_provider_proxy_selector_request, _rx_provider_proxy_selector_request) =
-                    mpsc::unbounded_channel::<ProviderProxySelectorRequestKind>();
-
-                let entity_map: Arc<Mutex<HashMap<EntityID, Option<Entity>>>> =
-                    Arc::new(Mutex::new(HashMap::new()));
-
-                let provider_proxy_selector_request_sender = Arc::new(
-                    ProviderProxySelectorRequestSender::new(tx_provider_proxy_selector_request),
-                );
-                let result = ibeji_digital_twin_adapter
-                    .init_provider_proxies_with_entities(
-                        entity_map,
-                        provider_proxy_selector_request_sender,
-                    )
-                    .await;
-                assert!(result.is_ok());
-            };
-
-            tokio::select! {
-                _ = run_test_grpc_server(uds_stream) => (),
-                _ = request_future => ()
-            }
-
-            std::fs::remove_file(bind_path.as_ref()).unwrap();
         }
 
         #[tokio::test]

--- a/digital_twin_adapters/ibeji_adapter/src/ibeji_adapter.rs
+++ b/digital_twin_adapters/ibeji_adapter/src/ibeji_adapter.rs
@@ -28,7 +28,7 @@ use dts_contracts::{
     },
     entity::{Entity, EntityID},
     provider_proxy::OperationKind,
-    provider_proxy_request:: ProviderProxySelectorRequestSender,
+    provider_proxy_request::ProviderProxySelectorRequestSender,
 };
 
 const GET_OPERATION: &str = "Get";
@@ -189,7 +189,11 @@ impl DigitalTwinAdapter for IbejiAdapter {
         provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
     ) -> Result<(), DigitalTwinAdapterError> {
         loop {
-            self.update_entity_map(entity_map.clone(),provider_proxy_selector_request_sender.clone()).await?;
+            self.update_entity_map(
+                entity_map.clone(),
+                provider_proxy_selector_request_sender.clone(),
+            )
+            .await?;
             tokio::time::sleep(sleep_interval).await;
         }
     }

--- a/digital_twin_adapters/in_memory_mock_digital_twin_adapter/Cargo.toml
+++ b/digital_twin_adapters/in_memory_mock_digital_twin_adapter/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-dts-contracts = { path = "../../contracts" }
 async-trait = { workspace = true }
+dts-contracts = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/digital_twin_adapters/in_memory_mock_digital_twin_adapter/Cargo.toml
+++ b/digital_twin_adapters/in_memory_mock_digital_twin_adapter/Cargo.toml
@@ -14,4 +14,3 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-log = { workspace = true }

--- a/digital_twin_adapters/in_memory_mock_digital_twin_adapter/src/in_memory_mock_digital_twin_adapter.rs
+++ b/digital_twin_adapters/in_memory_mock_digital_twin_adapter/src/in_memory_mock_digital_twin_adapter.rs
@@ -89,7 +89,11 @@ impl DigitalTwinAdapter for InMemoryMockDigitalTwinAdapter {
         provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
     ) -> Result<(), DigitalTwinAdapterError> {
         loop {
-            self.update_entity_map(entity_map.clone(), provider_proxy_selector_request_sender.clone()).await?;
+            self.update_entity_map(
+                entity_map.clone(),
+                provider_proxy_selector_request_sender.clone(),
+            )
+            .await?;
             tokio::time::sleep(sleep_interval).await;
         }
     }

--- a/digital_twin_adapters/mock_digital_twin_adapter/Cargo.toml
+++ b/digital_twin_adapters/mock_digital_twin_adapter/Cargo.toml
@@ -11,11 +11,10 @@ license = "MIT"
 [dependencies]
 dts-contracts = { path = "../../contracts" }
 mock-digital-twin = { path = "../../mocks/mock_digital_twin"}
-reqwest = { workspace = true }
 async-trait = { workspace = true }
-tokio = { workspace = true }
-log = { workspace = true }
-serde_json = { workspace = true }
 httptest = { workspace = true }
-tower = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tower = { workspace = true }

--- a/digital_twin_adapters/mock_digital_twin_adapter/Cargo.toml
+++ b/digital_twin_adapters/mock_digital_twin_adapter/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-dts-contracts = { path = "../../contracts" }
-mock-digital-twin = { path = "../../mocks/mock_digital_twin"}
 async-trait = { workspace = true }
+dts-contracts = { workspace = true }
 httptest = { workspace = true }
+mock-digital-twin = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/digital_twin_adapters/mock_digital_twin_adapter/src/mock_digital_twin_adapter.rs
+++ b/digital_twin_adapters/mock_digital_twin_adapter/src/mock_digital_twin_adapter.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 use std::{fs, path::Path};
 
 use async_trait::async_trait;
-use log::error;
 use reqwest::Client;
 use serde_json;
 
@@ -18,9 +17,7 @@ use dts_contracts::digital_twin_adapter::{
     GetDigitalTwinProviderResponse,
 };
 use dts_contracts::entity::{Entity, EntityID};
-use dts_contracts::provider_proxy_request::{
-    ProviderProxySelectorRequestKind, ProviderProxySelectorRequestSender,
-};
+use dts_contracts::provider_proxy_request::ProviderProxySelectorRequestSender;
 use mock_digital_twin::ENTITY_QUERY_PATH;
 
 /// Mocks a Digital Twin Adapter that calls the mocks/mock_digital_twin
@@ -110,47 +107,7 @@ impl DigitalTwinAdapter for MockDigitalTwinAdapter {
         provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
     ) -> Result<(), DigitalTwinAdapterError> {
         loop {
-            let mut entity_map_update = { entity_map.lock().unwrap().clone() };
-
-            // Update the copy of entity map if it contains an entity that has no information
-            for (entity_id, entity) in entity_map_update.iter_mut() {
-                if entity.is_some() {
-                    continue;
-                }
-
-                // Update the copy of entity map if we're able to find the info of an entity after doing find_by_id
-                let request = GetDigitalTwinProviderRequest {
-                    entity_id: entity_id.clone(),
-                };
-
-                match self.find_by_id(request).await {
-                    Ok(response) => {
-                        let entity_info = response.entity.clone();
-                        let (id, uri, protocol, operation) = (
-                            entity_info.id,
-                            entity_info.uri,
-                            entity_info.protocol,
-                            entity_info.operation,
-                        );
-                        *entity = Some(response.entity);
-
-                        // Notify the provider proxy selector to start a proxy
-                        let request = ProviderProxySelectorRequestKind::CreateOrUpdateProviderProxy(
-                            id, uri, protocol, operation,
-                        );
-                        provider_proxy_selector_request_sender
-                            .send_request_to_provider_proxy_selector(request);
-                    }
-                    Err(err) => {
-                        error!("{err}");
-                        *entity = None
-                    }
-                };
-            }
-
-            {
-                *entity_map.lock().unwrap() = entity_map_update;
-            }
+            self.update_entity_map(entity_map.clone(), provider_proxy_selector_request_sender.clone()).await?;
             tokio::time::sleep(sleep_interval).await;
         }
     }

--- a/digital_twin_adapters/mock_digital_twin_adapter/src/mock_digital_twin_adapter.rs
+++ b/digital_twin_adapters/mock_digital_twin_adapter/src/mock_digital_twin_adapter.rs
@@ -107,7 +107,11 @@ impl DigitalTwinAdapter for MockDigitalTwinAdapter {
         provider_proxy_selector_request_sender: Arc<ProviderProxySelectorRequestSender>,
     ) -> Result<(), DigitalTwinAdapterError> {
         loop {
-            self.update_entity_map(entity_map.clone(), provider_proxy_selector_request_sender.clone()).await?;
+            self.update_entity_map(
+                entity_map.clone(),
+                provider_proxy_selector_request_sender.clone(),
+            )
+            .await?;
             tokio::time::sleep(sleep_interval).await;
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.68"
+channel = "1.70"


### PR DESCRIPTION
All three of the digital twin adapters were using near-identical code to update their entity map. This was moved to a trait method with a default implementation to reduce the amount of copied code