### PR TITLE
Make operation generic and proxy-defined

### DIFF
--- a/common/src/signal_store.rs
+++ b/common/src/signal_store.rs
@@ -297,7 +297,7 @@ mod signal_store_tests {
                 name: Some(INCOMING.to_string()),
                 uri: INCOMING.to_string(),
                 description: Some(INCOMING.to_string()),
-                operation: String::from("FooOperation"),
+                operation: "FooOperation".to_string(),
                 protocol: INCOMING.to_string(),
             },
             target: Target {

--- a/common/src/signal_store.rs
+++ b/common/src/signal_store.rs
@@ -168,16 +168,17 @@ impl Default for SignalStore {
 
 #[cfg(test)]
 mod signal_store_tests {
+    use super::*;
+
     use std::collections::HashSet;
 
     use freyja_contracts::{
         conversion::Conversion,
         entity::Entity,
-        provider_proxy::OperationKind,
         signal::{Emission, EmissionPolicy, Target},
     };
 
-    use super::*;
+    const GET_OPERATION: &str = "Get";
 
     #[test]
     fn get_returns_existing_signal() {
@@ -267,7 +268,7 @@ mod signal_store_tests {
                 name: Some(ORIGINAL.to_string()),
                 uri: ORIGINAL.to_string(),
                 description: Some(ORIGINAL.to_string()),
-                operation: OperationKind::Get,
+                operation: GET_OPERATION.to_string(),
                 protocol: ORIGINAL.to_string(),
             },
             target: Target {
@@ -296,7 +297,7 @@ mod signal_store_tests {
                 name: Some(INCOMING.to_string()),
                 uri: INCOMING.to_string(),
                 description: Some(INCOMING.to_string()),
-                operation: OperationKind::Subscribe,
+                operation: String::from("FooOperation"),
                 protocol: INCOMING.to_string(),
             },
             target: Target {
@@ -366,7 +367,7 @@ mod signal_store_tests {
                 name: Some(INCOMING.to_string()),
                 uri: INCOMING.to_string(),
                 description: Some(INCOMING.to_string()),
-                operation: OperationKind::Subscribe,
+                operation: GET_OPERATION.to_string(),
                 protocol: INCOMING.to_string(),
             },
             target: Target {
@@ -429,7 +430,7 @@ mod signal_store_tests {
                 name: Some(ORIGINAL.to_string()),
                 uri: ORIGINAL.to_string(),
                 description: Some(ORIGINAL.to_string()),
-                operation: OperationKind::Get,
+                operation: GET_OPERATION.to_string(),
                 protocol: ORIGINAL.to_string(),
             },
             target: Target {

--- a/contracts/src/digital_twin_adapter.rs
+++ b/contracts/src/digital_twin_adapter.rs
@@ -39,26 +39,6 @@ pub struct GetDigitalTwinProviderResponse {
     pub entity: Entity,
 }
 
-/// A request for an entity's value
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EntityValueRequest {
-    /// The entity's ID
-    pub entity_id: String,
-
-    /// The callback uri for a provider to send data back
-    pub callback_uri: String,
-}
-
-/// A response for an entity's value
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EntityValueResponse {
-    // The id of the entity
-    pub entity_id: String,
-
-    /// The value of the entity
-    pub value: String,
-}
-
 proc_macros::error! {
     DigitalTwinAdapterError {
         EntityNotFound,

--- a/contracts/src/entity.rs
+++ b/contracts/src/entity.rs
@@ -4,10 +4,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::provider_proxy::OperationKind;
-
 /// Represents an entity
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Entity {
     /// The entity's id
     pub id: String,
@@ -22,21 +20,8 @@ pub struct Entity {
     pub description: Option<String>,
 
     /// The operation that we will use for this entity
-    pub operation: OperationKind,
+    pub operation: String,
 
     /// The protocol to use to contact this entity
     pub protocol: String,
-}
-
-impl Default for Entity {
-    fn default() -> Self {
-        Self {
-            id: Default::default(),
-            name: Default::default(),
-            uri: Default::default(),
-            description: Default::default(),
-            operation: OperationKind::Get,
-            protocol: Default::default(),
-        }
-    }
 }

--- a/contracts/src/provider_proxy.rs
+++ b/contracts/src/provider_proxy.rs
@@ -6,19 +6,8 @@ use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use crossbeam::queue::SegQueue;
-use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
 
-#[derive(Debug, EnumString, Display, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[strum(ascii_case_insensitive)]
-pub enum OperationKind {
-    #[strum(serialize = "Get")]
-    Get,
-    #[strum(serialize = "Subscribe")]
-    Subscribe,
-}
-
-/// Represesnts a new signal value
+/// Represents a signal value
 pub struct SignalValue {
     /// The entity's id
     pub entity_id: String,
@@ -59,14 +48,14 @@ pub trait ProviderProxy: Debug {
     async fn register_entity(
         &self,
         entity_id: &str,
-        operation: &OperationKind,
+        operation: &String,
     ) -> Result<(), ProviderProxyError>;
 
     /// Checks if this operation is supported
     ///
     /// # Arguments
     /// - `operation`: check to see if this operation is supported by this provider proxy
-    fn is_operation_supported(operation: &OperationKind) -> bool
+    fn is_operation_supported(operation: &String) -> bool
     where
         Self: Sized + Send + Sync;
 }
@@ -80,31 +69,5 @@ proc_macros::error! {
         Communication,
         EntityNotFound,
         Unknown
-    }
-}
-
-#[cfg(test)]
-mod provider_proxy_tests {
-    use super::*;
-
-    use std::str::FromStr;
-
-    #[test]
-    fn provider_proxy_kind_match_test() {
-        let mut subscribe = String::from("sUbScriBe");
-        let mut operation_kind = OperationKind::from_str(&subscribe).unwrap();
-        assert_eq!(operation_kind, OperationKind::Subscribe);
-
-        subscribe = String::from("Subscribe");
-        operation_kind = OperationKind::from_str(&subscribe).unwrap();
-        assert_eq!(operation_kind, OperationKind::Subscribe);
-
-        let mut get = String::from("gET");
-        operation_kind = OperationKind::from_str(&get).unwrap();
-        assert_eq!(operation_kind, OperationKind::Get);
-
-        get = String::from("Get");
-        operation_kind = OperationKind::from_str(&get).unwrap();
-        assert_eq!(operation_kind, OperationKind::Get);
     }
 }

--- a/contracts/src/provider_proxy.rs
+++ b/contracts/src/provider_proxy.rs
@@ -48,14 +48,14 @@ pub trait ProviderProxy: Debug {
     async fn register_entity(
         &self,
         entity_id: &str,
-        operation: &String,
+        operation: &str,
     ) -> Result<(), ProviderProxyError>;
 
     /// Checks if this operation is supported
     ///
     /// # Arguments
     /// - `operation`: check to see if this operation is supported by this provider proxy
-    fn is_operation_supported(operation: &String) -> bool
+    fn is_operation_supported(operation: &str) -> bool
     where
         Self: Sized + Send + Sync;
 }

--- a/digital_twin_adapters/in_memory_mock_digital_twin_adapter/src/in_memory_mock_digital_twin_adapter.rs
+++ b/digital_twin_adapters/in_memory_mock_digital_twin_adapter/src/in_memory_mock_digital_twin_adapter.rs
@@ -69,7 +69,9 @@ mod in_memory_mock_digital_twin_adapter_tests {
     use super::*;
 
     use crate::config::EntityConfig;
-    use freyja_contracts::{entity::Entity, provider_proxy::OperationKind};
+    use freyja_contracts::entity::Entity;
+
+    const OPERATION: &str = "Subscribe";
 
     #[test]
     fn can_create_new() {
@@ -88,7 +90,7 @@ mod in_memory_mock_digital_twin_adapter_tests {
                     name: None,
                     uri: String::from("http://0.0.0.0:1111"), // Devskim: ignore DS137138
                     description: None,
-                    operation: OperationKind::Subscribe,
+                    operation: OPERATION.to_string(),
                     protocol: String::from("in-memory"),
                 },
             }],
@@ -103,6 +105,6 @@ mod in_memory_mock_digital_twin_adapter_tests {
             .await
             .unwrap();
         assert_eq!(response.entity.id, ENTITY_ID);
-        assert_eq!(response.entity.operation, OperationKind::Subscribe);
+        assert_eq!(response.entity.operation, OPERATION);
     }
 }

--- a/freyja/src/cartographer.rs
+++ b/freyja/src/cartographer.rs
@@ -218,7 +218,6 @@ mod cartographer_tests {
             CheckForWorkResponse, GetMappingResponse, MappingClientError, SendInventoryRequest,
             SendInventoryResponse,
         },
-        provider_proxy::OperationKind,
         provider_proxy_selector::ProviderProxySelectorError,
     };
 
@@ -333,7 +332,7 @@ mod cartographer_tests {
             name: Some("name".to_string()),
             uri: "uri".to_string(),
             description: Some("description".to_string()),
-            operation: OperationKind::Get,
+            operation: "FooOperation".to_string(),
             protocol: "in-memory".to_string(),
         };
 

--- a/mocks/mock_digital_twin/Cargo.toml
+++ b/mocks/mock_digital_twin/Cargo.toml
@@ -17,6 +17,7 @@ log = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
+http-mock-provider-proxy = { path = "../../provider_proxies/http_mock_provider_proxy" }
 
 [build-dependencies]
 freyja-build-common = { workspace = true }

--- a/mocks/mock_digital_twin/src/main.rs
+++ b/mocks/mock_digital_twin/src/main.rs
@@ -254,10 +254,9 @@ async fn get_entity(
     let state = state.lock().unwrap();
     find_entity(&state, &query.id)
         .map(|(config_item, _)| {
-            let operation_path = if config_item.entity.operation.to_string() == SUBSCRIBE_OPERATION
-            {
+            let operation_path = if config_item.entity.operation == SUBSCRIBE_OPERATION {
                 ENTITY_SUBSCRIBE_PATH
-            } else if config_item.entity.operation.to_string() == GET_OPERATION {
+            } else if config_item.entity.operation == GET_OPERATION {
                 ENTITY_GET_VALUE_PATH
             } else {
                 return server_error!("Entity didn't have a valid operation");

--- a/mocks/mock_digital_twin/src/main.rs
+++ b/mocks/mock_digital_twin/src/main.rs
@@ -13,15 +13,14 @@ use axum::routing::{get, post};
 use axum::{extract, extract::State, Json, Router, Server};
 use env_logger::Target;
 use freyja_common::{config_utils, out_dir};
+use http_mock_provider_proxy::http_mock_provider_proxy::{EntityValueRequest, EntityValueResponse};
 use log::{debug, error, info, warn, LevelFilter};
 use reqwest::Client;
 use serde::Deserialize;
 use tokio::sync::{mpsc, mpsc::UnboundedSender};
 
 use crate::config::{Config, EntityConfig};
-use freyja_contracts::digital_twin_adapter::{
-    EntityValueRequest, EntityValueResponse, GetDigitalTwinProviderResponse,
-};
+use freyja_contracts::digital_twin_adapter::GetDigitalTwinProviderResponse;
 use mock_digital_twin::{ENTITY_GET_VALUE_PATH, ENTITY_PATH, ENTITY_SUBSCRIBE_PATH};
 
 const CONFIG_FILE_STEM: &str = "mock_digital_twin_config";

--- a/mocks/mock_digital_twin/src/main.rs
+++ b/mocks/mock_digital_twin/src/main.rs
@@ -12,15 +12,15 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{extract, extract::State, Json, Router, Server};
 use env_logger::Target;
-use freyja_common::{config_utils, out_dir};
-use http_mock_provider_proxy::http_mock_provider_proxy::{EntityValueRequest, EntityValueResponse};
 use log::{debug, error, info, warn, LevelFilter};
 use reqwest::Client;
 use serde::Deserialize;
 use tokio::sync::{mpsc, mpsc::UnboundedSender};
 
 use crate::config::{Config, EntityConfig};
+use freyja_common::{config_utils, out_dir};
 use freyja_contracts::digital_twin_adapter::GetDigitalTwinProviderResponse;
+use http_mock_provider_proxy::http_mock_provider_proxy::{EntityValueRequest, EntityValueResponse};
 use mock_digital_twin::{ENTITY_GET_VALUE_PATH, ENTITY_PATH, ENTITY_SUBSCRIBE_PATH};
 
 const CONFIG_FILE_STEM: &str = "mock_digital_twin_config";

--- a/provider_proxies/grpc/v1/README.md
+++ b/provider_proxies/grpc/v1/README.md
@@ -1,6 +1,6 @@
 # GRPC Provider Proxy
 
-The GRPC Provider Proxy interfaces with providers which support GRPC. It acts as a consumer for digital twin providers. This proxy supports the operations `Get` and `Subscribe` as defined for the [Ibeji mixed sample](https://github.com/eclipse-ibeji/ibeji/tree/main/samples/mixed). To use this proxy with other providers, those providers will need to support the same APIs as the provider in the Ibeji mixed sample.
+The GRPC Provider Proxy interfaces with providers which support GRPC. It acts as a consumer for digital twin providers. This proxy supports the `Get` and `Subscribe` operations as defined for the [Ibeji mixed sample](https://github.com/eclipse-ibeji/ibeji/tree/main/samples/mixed). To use this proxy with other providers, those providers will need to support the same API(s) as the provider in that sample.
 
 ## Configuration
 

--- a/provider_proxies/grpc/v1/src/config.rs
+++ b/provider_proxies/grpc/v1/src/config.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// The in-memory mock mapping client's config
+/// The GRPC provider proxy config
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
     /// The set of config values

--- a/provider_proxies/grpc/v1/src/grpc_provider_proxy.rs
+++ b/provider_proxies/grpc/v1/src/grpc_provider_proxy.rs
@@ -150,14 +150,14 @@ impl ProviderProxy for GRPCProviderProxy {
     async fn register_entity(
         &self,
         entity_id: &str,
-        operation: &String,
+        operation: &str,
     ) -> Result<(), ProviderProxyError> {
         self.entity_operation_map
             .lock()
             .unwrap()
-            .insert(String::from(entity_id), operation.clone());
+            .insert(String::from(entity_id), String::from(operation));
 
-        if *operation == SUBSCRIBE_OPERATION {
+        if operation == SUBSCRIBE_OPERATION {
             let consumer_uri = format!("http://{}", self.config.consumer_address); // Devskim: ignore DS137138
             let mut client = self.provider_client.clone();
             let request = tonic::Request::new(SubscribeRequest {
@@ -183,8 +183,8 @@ impl ProviderProxy for GRPCProviderProxy {
     ///
     /// # Arguments
     /// - `operation`: check to see if this operation is supported by this provider proxy
-    fn is_operation_supported(operation: &String) -> bool {
-        SUPPORTED_OPERATIONS.contains(&operation.as_str())
+    fn is_operation_supported(operation: &str) -> bool {
+        SUPPORTED_OPERATIONS.contains(&operation)
     }
 }
 

--- a/provider_proxies/grpc/v1/src/grpc_provider_proxy.rs
+++ b/provider_proxies/grpc/v1/src/grpc_provider_proxy.rs
@@ -326,7 +326,7 @@ mod grpc_provider_proxy_v1_tests {
                 let entity_id = "operation_get_entity_id";
 
                 let result = grpc_provider_proxy
-                    .register_entity(entity_id, &GET_OPERATION.to_string())
+                    .register_entity(entity_id, GET_OPERATION)
                     .await;
                 assert!(result.is_ok());
                 assert!(grpc_provider_proxy
@@ -336,7 +336,7 @@ mod grpc_provider_proxy_v1_tests {
 
                 let entity_id = "operation_subscribe_entity_id";
                 let result = grpc_provider_proxy
-                    .register_entity(entity_id, &SUBSCRIBE_OPERATION.to_string())
+                    .register_entity(entity_id, SUBSCRIBE_OPERATION)
                     .await;
                 assert!(result.is_ok());
                 assert!(grpc_provider_proxy

--- a/provider_proxies/grpc/v1/src/grpc_provider_proxy.rs
+++ b/provider_proxies/grpc/v1/src/grpc_provider_proxy.rs
@@ -20,12 +20,12 @@ use samples_protobuf_data_access::sample_grpc::v1::{
 use tonic::transport::{Channel, Server};
 
 use crate::{config::Config, grpc_client_impl::GRPCClientImpl};
-use freyja_contracts::provider_proxy::{
-    OperationKind, ProviderProxy, ProviderProxyError, SignalValue,
-};
+use freyja_contracts::provider_proxy::{ProviderProxy, ProviderProxyError, SignalValue};
 
 const CONFIG_FILE_STEM: &str = "grpc_proxy_config";
-const SUPPORTED_OPERATIONS: &[OperationKind] = &[OperationKind::Get, OperationKind::Subscribe];
+const GET_OPERATION: &str = "Get";
+const SUBSCRIBE_OPERATION: &str = "Subscribe";
+const SUPPORTED_OPERATIONS: &[&str] = &[GET_OPERATION, SUBSCRIBE_OPERATION];
 
 /// Interfaces with providers which support GRPC. Based on the Ibeji mixed sample.
 #[derive(Debug)]
@@ -37,7 +37,7 @@ pub struct GRPCProviderProxy {
     provider_client: DigitalTwinProviderClient<Channel>,
 
     /// Local cache for keeping track of which entities this provider proxy contains
-    entity_operation_map: Mutex<HashMap<String, OperationKind>>,
+    entity_operation_map: Mutex<HashMap<String, String>>,
 
     /// Shared queue for all proxies to push new signal values of entities
     signal_values_queue: Arc<SegQueue<SignalValue>>,
@@ -126,7 +126,7 @@ impl ProviderProxy for GRPCProviderProxy {
 
         // Only need to handle Get operations since subscribe has already happened
         let operation = operation_result.unwrap();
-        if operation == OperationKind::Get {
+        if operation == GET_OPERATION {
             let mut client = self.provider_client.clone();
             let request = tonic::Request::new(GetRequest {
                 entity_id: String::from(entity_id),
@@ -150,14 +150,14 @@ impl ProviderProxy for GRPCProviderProxy {
     async fn register_entity(
         &self,
         entity_id: &str,
-        operation: &OperationKind,
+        operation: &String,
     ) -> Result<(), ProviderProxyError> {
         self.entity_operation_map
             .lock()
             .unwrap()
             .insert(String::from(entity_id), operation.clone());
 
-        if *operation == OperationKind::Subscribe {
+        if *operation == SUBSCRIBE_OPERATION {
             let consumer_uri = format!("http://{}", self.config.consumer_address); // Devskim: ignore DS137138
             let mut client = self.provider_client.clone();
             let request = tonic::Request::new(SubscribeRequest {
@@ -183,8 +183,8 @@ impl ProviderProxy for GRPCProviderProxy {
     ///
     /// # Arguments
     /// - `operation`: check to see if this operation is supported by this provider proxy
-    fn is_operation_supported(operation: &OperationKind) -> bool {
-        SUPPORTED_OPERATIONS.contains(operation)
+    fn is_operation_supported(operation: &String) -> bool {
+        SUPPORTED_OPERATIONS.contains(&operation.as_str())
     }
 }
 
@@ -326,7 +326,7 @@ mod grpc_provider_proxy_v1_tests {
                 let entity_id = "operation_get_entity_id";
 
                 let result = grpc_provider_proxy
-                    .register_entity(entity_id, &OperationKind::Get)
+                    .register_entity(entity_id, &GET_OPERATION.to_string())
                     .await;
                 assert!(result.is_ok());
                 assert!(grpc_provider_proxy
@@ -336,7 +336,7 @@ mod grpc_provider_proxy_v1_tests {
 
                 let entity_id = "operation_subscribe_entity_id";
                 let result = grpc_provider_proxy
-                    .register_entity(entity_id, &OperationKind::Subscribe)
+                    .register_entity(entity_id, &SUBSCRIBE_OPERATION.to_string())
                     .await;
                 assert!(result.is_ok());
                 assert!(grpc_provider_proxy

--- a/provider_proxies/http_mock_provider_proxy/src/http_mock_provider_proxy.rs
+++ b/provider_proxies/http_mock_provider_proxy/src/http_mock_provider_proxy.rs
@@ -228,14 +228,14 @@ impl ProviderProxy for HttpMockProviderProxy {
     async fn register_entity(
         &self,
         entity_id: &str,
-        operation: &String,
+        operation: &str,
     ) -> Result<(), ProviderProxyError> {
         self.entity_operation_map
             .lock()
             .unwrap()
-            .insert(String::from(entity_id), operation.clone());
+            .insert(String::from(entity_id), String::from(operation));
 
-        if *operation != SUBSCRIBE_OPERATION {
+        if operation != SUBSCRIBE_OPERATION {
             return Ok(());
         }
 
@@ -269,7 +269,7 @@ impl ProviderProxy for HttpMockProviderProxy {
     ///
     /// # Arguments
     /// - `operation`: check to see if this operation is supported by this provider proxy
-    fn is_operation_supported(operation: &String) -> bool {
-        SUPPORTED_OPERATIONS.contains(&operation.as_str())
+    fn is_operation_supported(operation: &str) -> bool {
+        SUPPORTED_OPERATIONS.contains(&operation)
     }
 }

--- a/provider_proxies/http_mock_provider_proxy/src/http_mock_provider_proxy.rs
+++ b/provider_proxies/http_mock_provider_proxy/src/http_mock_provider_proxy.rs
@@ -14,15 +14,15 @@ use crossbeam::queue::SegQueue;
 use freyja_common::{config_utils, out_dir};
 use log::{debug, error, info};
 use reqwest::Client;
+use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
-use freyja_contracts::digital_twin_adapter::{EntityValueRequest, EntityValueResponse};
-use freyja_contracts::provider_proxy::{
-    OperationKind, ProviderProxy, ProviderProxyError, SignalValue,
-};
+use freyja_contracts::provider_proxy::{ProviderProxy, ProviderProxyError, SignalValue};
 
 const CONFIG_FILE_STEM: &str = "http_mock_provider_proxy";
-const SUPPORTED_OPERATIONS: &[OperationKind] = &[OperationKind::Get, OperationKind::Subscribe];
+const GET_OPERATION: &str = "Get";
+const SUBSCRIBE_OPERATION: &str = "Subscribe";
+const SUPPORTED_OPERATIONS: &[&str] = &[GET_OPERATION, SUBSCRIBE_OPERATION];
 const CALLBACK_FOR_VALUES_PATH: &str = "/value";
 
 macro_rules! ok {
@@ -34,6 +34,26 @@ macro_rules! ok {
     };
 }
 
+/// A request for an entity's value
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EntityValueRequest {
+    /// The entity's ID
+    pub entity_id: String,
+
+    /// The callback uri for a provider to send data back
+    pub callback_uri: String,
+}
+
+/// A response for an entity's value
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EntityValueResponse {
+    // The id of the entity
+    pub entity_id: String,
+
+    /// The value of the entity
+    pub value: String,
+}
+
 /// A provider proxy for our HTTP mocks/mock_digital_twin
 #[derive(Debug)]
 pub struct HttpMockProviderProxy {
@@ -41,7 +61,7 @@ pub struct HttpMockProviderProxy {
     client: Client,
 
     /// Local cache for keeping track of which entities this provider proxy contains
-    entity_operation_map: Mutex<HashMap<String, OperationKind>>,
+    entity_operation_map: Mutex<HashMap<String, String>>,
 
     /// Shared queue for all proxies to push new signal values
     signal_values_queue: Arc<SegQueue<SignalValue>>,
@@ -177,7 +197,7 @@ impl ProviderProxy for HttpMockProviderProxy {
 
         // Only need to handle Get operations since subscribe has already happened
         let operation = operation_result.unwrap();
-        if operation == OperationKind::Get {
+        if operation == GET_OPERATION {
             info!("Sending a get request to {entity_id}");
 
             let request = EntityValueRequest {
@@ -208,14 +228,14 @@ impl ProviderProxy for HttpMockProviderProxy {
     async fn register_entity(
         &self,
         entity_id: &str,
-        operation: &OperationKind,
+        operation: &String,
     ) -> Result<(), ProviderProxyError> {
         self.entity_operation_map
             .lock()
             .unwrap()
             .insert(String::from(entity_id), operation.clone());
 
-        if *operation != OperationKind::Subscribe {
+        if *operation != SUBSCRIBE_OPERATION {
             return Ok(());
         }
 
@@ -249,7 +269,7 @@ impl ProviderProxy for HttpMockProviderProxy {
     ///
     /// # Arguments
     /// - `operation`: check to see if this operation is supported by this provider proxy
-    fn is_operation_supported(operation: &OperationKind) -> bool {
-        SUPPORTED_OPERATIONS.contains(operation)
+    fn is_operation_supported(operation: &String) -> bool {
+        SUPPORTED_OPERATIONS.contains(&operation.as_str())
     }
 }

--- a/provider_proxies/in_memory_mock_provider_proxy/src/in_memory_provider_proxy.rs
+++ b/provider_proxies/in_memory_mock_provider_proxy/src/in_memory_provider_proxy.rs
@@ -16,12 +16,12 @@ use freyja_common::{config_utils, out_dir};
 use log::info;
 
 use crate::config::{Config, EntityConfig};
-use freyja_contracts::provider_proxy::{
-    OperationKind, ProviderProxy, ProviderProxyError, SignalValue,
-};
+use freyja_contracts::provider_proxy::{ProviderProxy, ProviderProxyError, SignalValue};
 
 const CONFIG_FILE_STEM: &str = "in_memory_mock_proxy_config";
-const SUPPORTED_OPERATIONS: &[OperationKind] = &[OperationKind::Get, OperationKind::Subscribe];
+const GET_OPERATION: &str = "Get";
+const SUBSCRIBE_OPERATION: &str = "Subscribe";
+const SUPPORTED_OPERATIONS: &[&str] = &[GET_OPERATION, SUBSCRIBE_OPERATION];
 
 #[derive(Debug)]
 pub struct InMemoryMockProviderProxy {
@@ -29,7 +29,7 @@ pub struct InMemoryMockProviderProxy {
     data: HashMap<String, (EntityConfig, AtomicU8)>,
 
     /// Local cache for keeping track of which entities this provider proxy contains
-    entity_operation_map: Mutex<HashMap<String, OperationKind>>,
+    entity_operation_map: Mutex<HashMap<String, String>>,
 
     /// Shared queue for all proxies to push new signal values of entities
     signal_values_queue: Arc<SegQueue<SignalValue>>,
@@ -126,7 +126,7 @@ impl ProviderProxy for InMemoryMockProviderProxy {
                     .unwrap()
                     .clone()
                     .into_iter()
-                    .filter(|(_, operation)| *operation == OperationKind::Subscribe)
+                    .filter(|(_, operation)| *operation == SUBSCRIBE_OPERATION)
                     .map(|(entity_id, _)| entity_id)
                     .collect();
             }
@@ -162,7 +162,7 @@ impl ProviderProxy for InMemoryMockProviderProxy {
 
         // Only need to handle Get operations since subscribe has already happened
         let operation = operation_result.unwrap();
-        if operation == OperationKind::Get {
+        if operation == GET_OPERATION {
             let _ = Self::generate_signal_value(
                 entity_id,
                 self.signal_values_queue.clone(),
@@ -182,7 +182,7 @@ impl ProviderProxy for InMemoryMockProviderProxy {
     async fn register_entity(
         &self,
         entity_id: &str,
-        operation: &OperationKind,
+        operation: &String,
     ) -> Result<(), ProviderProxyError> {
         self.entity_operation_map
             .lock()
@@ -195,8 +195,8 @@ impl ProviderProxy for InMemoryMockProviderProxy {
     ///
     /// # Arguments
     /// - `operation`: check to see if this operation is supported by this provider proxy
-    fn is_operation_supported(operation: &OperationKind) -> bool {
-        SUPPORTED_OPERATIONS.contains(operation)
+    fn is_operation_supported(operation: &String) -> bool {
+        SUPPORTED_OPERATIONS.contains(&operation.as_str())
     }
 }
 

--- a/provider_proxies/in_memory_mock_provider_proxy/src/in_memory_provider_proxy.rs
+++ b/provider_proxies/in_memory_mock_provider_proxy/src/in_memory_provider_proxy.rs
@@ -182,12 +182,12 @@ impl ProviderProxy for InMemoryMockProviderProxy {
     async fn register_entity(
         &self,
         entity_id: &str,
-        operation: &String,
+        operation: &str,
     ) -> Result<(), ProviderProxyError> {
         self.entity_operation_map
             .lock()
             .unwrap()
-            .insert(String::from(entity_id), operation.clone());
+            .insert(String::from(entity_id), String::from(operation));
         Ok(())
     }
 
@@ -195,8 +195,8 @@ impl ProviderProxy for InMemoryMockProviderProxy {
     ///
     /// # Arguments
     /// - `operation`: check to see if this operation is supported by this provider proxy
-    fn is_operation_supported(operation: &String) -> bool {
-        SUPPORTED_OPERATIONS.contains(&operation.as_str())
+    fn is_operation_supported(operation: &str) -> bool {
+        SUPPORTED_OPERATIONS.contains(&operation)
     }
 }
 

--- a/provider_proxy_selector/src/provider_proxy_selector_impl.rs
+++ b/provider_proxy_selector/src/provider_proxy_selector_impl.rs
@@ -68,7 +68,7 @@ impl ProviderProxyKind {
     /// - `signal_values_queue`: shared queue for all proxies to push new signal values of entities
     async fn create_provider_proxy(
         protocol: &str,
-        operation: &String,
+        operation: &str,
         provider_uri: &str,
         signal_values_queue: Arc<SegQueue<SignalValue>>,
     ) -> Result<ProviderProxyImpl, ProviderProxySelectorError> {

--- a/provider_proxy_selector/src/provider_proxy_selector_impl.rs
+++ b/provider_proxy_selector/src/provider_proxy_selector_impl.rs
@@ -15,7 +15,7 @@ use strum_macros::{Display, EnumString};
 
 use freyja_contracts::{
     entity::Entity,
-    provider_proxy::{OperationKind, ProviderProxy, ProviderProxyError, SignalValue},
+    provider_proxy::{ProviderProxy, ProviderProxyError, SignalValue},
     provider_proxy_selector::{ProviderProxySelector, ProviderProxySelectorError},
 };
 use grpc_provider_proxy_v1::grpc_provider_proxy::GRPCProviderProxy;
@@ -68,7 +68,7 @@ impl ProviderProxyKind {
     /// - `signal_values_queue`: shared queue for all proxies to push new signal values of entities
     async fn create_provider_proxy(
         protocol: &str,
-        operation: &OperationKind,
+        operation: &String,
         provider_uri: &str,
         signal_values_queue: Arc<SegQueue<SignalValue>>,
     ) -> Result<ProviderProxyImpl, ProviderProxySelectorError> {
@@ -241,11 +241,10 @@ impl ProviderProxySelector for ProviderProxySelectorImpl {
 mod provider_proxy_selector_tests {
     use super::*;
 
-    use freyja_contracts::{
-        provider_proxy::OperationKind, provider_proxy_selector::ProviderProxySelectorErrorKind,
-    };
+    use freyja_contracts::provider_proxy_selector::ProviderProxySelectorErrorKind;
 
     const AMBIENT_AIR_TEMPERATURE_ID: &str = "dtmi:sdv:Vehicle:Cabin:HVAC:AmbientAirTemperature;1";
+    const OPERATION: &str = "Subscribe";
 
     #[tokio::test]
     async fn handle_start_provider_proxy_request_return_err_test() {
@@ -257,7 +256,7 @@ mod provider_proxy_selector_tests {
             uri: String::new(),
             name: None,
             description: None,
-            operation: OperationKind::Subscribe,
+            operation: OPERATION.to_string(),
             protocol: String::from("grpc"),
         };
 


### PR DESCRIPTION
Operations are largely user-defined and vary based on the convention of the providers. Thus, operations should not have discrete values in Freyja and should instead be freeform strings like they are for Ibeji. In addition, proxies should define the operations that they support for themselves