### PR TITLE
Ignore aka.ms links in markdown link checker

### DIFF
--- a/tools/.markdownlinkcheck.jsonc
+++ b/tools/.markdownlinkcheck.jsonc
@@ -2,6 +2,10 @@
     "ignorePatterns": [
       {
         "pattern": "^http://localhost"
+      },
+      {
+        // Checking aka.ms links is unstable and frequently fails on valid links
+        "pattern": "^https://aka.ms"
       }
     ],
     "aliveStatusCodes": [


### PR DESCRIPTION
The markdown link checker is very unstable when checking aka.ms links, so this PR ignores such urls in the workflow