### PR TITLE
Workaround for current Ibeji provider contract

### DIFF
--- a/.accepted_words.txt
+++ b/.accepted_words.txt
@@ -59,6 +59,7 @@ ESDV
 EntityConfig
 fn
 Fólkvangr
+foo
 FREYJA
 Freyja
 Freyja's

--- a/.accepted_words.txt
+++ b/.accepted_words.txt
@@ -139,6 +139,7 @@ pre
 PrivateKeyName
 proto
 protobuf
+PublishRequest
 pushd
 queryable
 quickstart

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,7 @@ dependencies = [
  "log",
  "samples-protobuf-data-access",
  "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/provider_proxies/grpc/v1/Cargo.toml
+++ b/provider_proxies/grpc/v1/Cargo.toml
@@ -18,6 +18,7 @@ futures = { workspace = true }
 log = { workspace = true }
 samples-protobuf-data-access  = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }

--- a/provider_proxies/grpc/v1/README.md
+++ b/provider_proxies/grpc/v1/README.md
@@ -15,14 +15,16 @@ This adapter supports [config overrides](../../../docs/config-overrides.md). The
 This proxy supports the `Publish` API as [defined by the Ibeji samples](https://github.com/eclipse-ibeji/ibeji/blob/main/samples/interfaces/sample_grpc/v1/digital_twin_consumer.proto). In addition, the `value` property of the `PublishRequest` message that providers publish must conform to one of the following structures in order to properly extract the signal value:
 
 - A raw value as a string. For example, `"42"` or `"\"foo\""`.
-- A serialized JSON object with a property not named `$metadata` containing the signal value as a JSON primitive. If there is more than one propery that meets these criteria, the first one will be used. For example:
-```json
-{
-    "AmbientAirTemperature": 42,
-    "$metadata": {
-        "foo": "bar"
-    }
-}
-```
+<!--alex ignore primitive-->
+- A serialized JSON object with a property not named `$metadata` containing the signal value as a JSON primitive. If there is more than one property that meets these criteria, the first one will be used. For example:
 
-In the above example, this proxy would extract the value `"42"`.
+    ```json
+    {
+        "AmbientAirTemperature": 42,
+        "$metadata": {
+            "foo": "bar"
+        }
+    }
+    ```
+
+    In the above example, this proxy would extract the value `"42"`.

--- a/provider_proxies/grpc/v1/README.md
+++ b/provider_proxies/grpc/v1/README.md
@@ -21,7 +21,9 @@ This proxy supports the `Publish` API as [defined by the Ibeji samples](https://
 ```json
 {
     "AmbientAirTemperature": "42",
-    "$metadata": {...}
+    "$metadata": {
+        "foo": "bar",
+    }
 }
 ```
 

--- a/provider_proxies/grpc/v1/README.md
+++ b/provider_proxies/grpc/v1/README.md
@@ -14,15 +14,13 @@ This adapter supports [config overrides](../../../docs/config-overrides.md). The
 
 This proxy supports the `Publish` API as [defined by the Ibeji samples](https://github.com/eclipse-ibeji/ibeji/blob/main/samples/interfaces/sample_grpc/v1/digital_twin_consumer.proto). In addition, the `value` property of the `PublishRequest` message that providers publish must conform to one of the following structures in order to properly extract the signal value:
 
-- A raw value as a string. For example:
-    - `"42"`
-    - `"\"foo\""`
-- A serialized JSON object with a property not named `$metadata` containing the signal value as a string. If there is more than one propery not named `$metadata`, the first one will be used. For example:
+- A raw value as a string. For example, `"42"` or `"\"foo\""`.
+- A serialized JSON object with a property not named `$metadata` containing the signal value as a JSON primitive. If there is more than one propery that meets these criteria, the first one will be used. For example:
 ```json
 {
-    "AmbientAirTemperature": "42",
+    "AmbientAirTemperature": 42,
     "$metadata": {
-        "foo": "bar",
+        "foo": "bar"
     }
 }
 ```

--- a/provider_proxies/grpc/v1/README.md
+++ b/provider_proxies/grpc/v1/README.md
@@ -1,6 +1,6 @@
 # GRPC Provider Proxy
 
-The GRPC Provider Proxy interfaces with providers which support GRPC. It acts as a consumer for digital twin providers. This proxy supports the `Get` and `Subscribe` operations as defined for the [Ibeji mixed sample](https://github.com/eclipse-ibeji/ibeji/tree/main/samples/mixed). To use this proxy with other providers, those providers will need to support the same API(s) as the provider in that sample.
+The GRPC Provider Proxy interfaces with providers which support GRPC. It acts as a consumer for digital twin providers. This proxy supports the `Get` and `Subscribe` operations as defined for the [Ibeji mixed sample](https://github.com/eclipse-ibeji/ibeji/tree/main/samples/mixed). To use this proxy with other providers, those providers will need to support the same API(s) as the provider in that sample (see [Integrating with this Proxy](#integrating-with-this-proxy) for more information).
 
 ## Configuration
 
@@ -9,3 +9,20 @@ This proxy supports the following configuration settings:
 - `consumer_address`: The address for the proxy's consumer
 
 This adapter supports [config overrides](../../../docs/config-overrides.md). The override filename is `grpc_proxy_config.json`, and the default config is located at `res/grpc_proxy_config.default.json`.
+
+## Integrating with this Proxy
+
+This proxy supports the `Publish` API as [defined by the Ibeji samples](https://github.com/eclipse-ibeji/ibeji/blob/main/samples/interfaces/sample_grpc/v1/digital_twin_consumer.proto). In addition, the `value` property of the `PublishRequest` message that providers publish must conform to one of the following structures in order to properly extract the signal value:
+
+- A raw value as a string. For example:
+    - `"42"`
+    - `"\"foo\""`
+- A serialized JSON object with a property not named `$metadata` containing the signal value as a string. If there is more than one propery not named `$metadata`, the first one will be used. For example:
+```json
+{
+    "AmbientAirTemperature": "42",
+    "$metadata": {...}
+}
+```
+
+In the above example, this proxy would extract the value `"42"`.

--- a/provider_proxies/grpc/v1/README.md
+++ b/provider_proxies/grpc/v1/README.md
@@ -15,7 +15,7 @@ This adapter supports [config overrides](../../../docs/config-overrides.md). The
 This proxy supports the `Publish` API as [defined by the Ibeji samples](https://github.com/eclipse-ibeji/ibeji/blob/main/samples/interfaces/sample_grpc/v1/digital_twin_consumer.proto). In addition, the `value` property of the `PublishRequest` message that providers publish must conform to one of the following structures in order to properly extract the signal value:
 
 - A raw value as a string. For example, `"42"` or `"\"foo\""`.
-<!--alex ignore primitive-->
+<!--alex ignore savage-->
 - A serialized JSON object with a property not named `$metadata` containing the signal value as a JSON primitive. If there is more than one property that meets these criteria, the first one will be used. For example:
 
     ```json

--- a/provider_proxies/grpc/v1/src/grpc_client_impl.rs
+++ b/provider_proxies/grpc/v1/src/grpc_client_impl.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crossbeam::queue::SegQueue;
 use log::{debug, warn};
+use serde_json::Value;
 use tonic::{Request, Response, Status};
 
 use freyja_contracts::provider_proxy::SignalValue;
@@ -17,6 +18,12 @@ use samples_protobuf_data_access::sample_grpc::v1::digital_twin_consumer::{
 #[derive(Debug, Default)]
 pub struct GRPCClientImpl {
     pub signal_values_queue: Arc<SegQueue<SignalValue>>,
+}
+
+impl GRPCClientImpl {
+    fn parse_value(value: String) -> String {
+        
+    }
 }
 
 #[tonic::async_trait]
@@ -32,6 +39,15 @@ impl DigitalTwinConsumer for GRPCClientImpl {
         let PublishRequest { entity_id, value } = request.into_inner();
 
         debug!("Received a publish for entity id {entity_id} with the value {value}");
+
+        let deserialize_result = serde_json::from_str::<Value>(value);
+
+        let value = match deserialize_result {
+            Ok(v) => {
+                // Get the first property not called "$metadata" and assume that's the correct property
+                let foo = v.as_object()
+            }
+        }
 
         let new_signal_value = SignalValue { entity_id, value };
         self.signal_values_queue.push(new_signal_value);

--- a/provider_proxies/grpc/v1/src/grpc_client_impl.rs
+++ b/provider_proxies/grpc/v1/src/grpc_client_impl.rs
@@ -17,7 +17,7 @@ use samples_protobuf_data_access::sample_grpc::v1::digital_twin_consumer::{
 
 const METADATA_KEY: &str = "$metadata";
 
-/// Struct which implements the DigitalTwinConsumer trait for GRPC clients
+/// Struct which implements the DigitalTwinConsumer trait for gRPC clients
 #[derive(Debug, Default)]
 pub struct GRPCClientImpl {
     /// The queue on which incoming signal values should be published
@@ -79,11 +79,11 @@ impl GRPCClientImpl {
                             if property_map.contains_key(&METADATA_KEY.to_string()) {
                                 "has"
                             } else {
-                                "doesn't have"
+                                "does not have"
                             };
 
                         debug!(
-                            "Value contained {} properties and {metadata_descriptor} a $metadata property. Selecting property with key {} as the signal value",
+                            "Value contained {} properties and {metadata_descriptor} a {METADATA_KEY} property. Selecting property with key {} as the signal value",
                             property_map.len(),
                             k
                         );

--- a/provider_proxies/grpc/v1/src/grpc_client_impl.rs
+++ b/provider_proxies/grpc/v1/src/grpc_client_impl.rs
@@ -15,14 +15,84 @@ use samples_protobuf_data_access::sample_grpc::v1::digital_twin_consumer::{
     RespondRequest, RespondResponse,
 };
 
+const METADATA_KEY: &str = "$metadata";
+
+macro_rules! unwrap_or_return {
+    ($opt:expr, $ret:expr, $msg:literal) => {
+        match $opt {
+            Some(v) => v,
+            None => {
+                warn!($msg);
+                return $ret;
+            }
+        }
+    }
+}
+
+/// Struct which implements the DigitalTwinConsumer trait for GRPC clients
 #[derive(Debug, Default)]
 pub struct GRPCClientImpl {
+    /// The queue on which incoming signal values shoudl be published
     pub signal_values_queue: Arc<SegQueue<SignalValue>>,
 }
 
 impl GRPCClientImpl {
+    /// Parses the value published by a provider.
+    /// The current implementation is a workaround for the current Ibeji sample provider implementation,
+    /// which uses a non-consistent contract as follows:
+    /// 
+    /// ```ignore
+    /// {
+    ///     "{propertyName}": "value",
+    ///     "$metadata": {...}
+    /// }
+    /// ```
+    /// 
+    /// Note that `{propertyName}` is replaced by the name of the property that the provider published.
+    /// This method assumes that the first property not called `$metadata` is the one we're interested in,
+    /// and will attempt to extract and return the value of that property.
+    /// If any part of parsing fails, a warning is logged and the original value is returned.
+    /// 
+    /// # Arguments
+    /// - `value`: the value to attempt to parse
     fn parse_value(value: String) -> String {
-        
+        match serde_json::from_str::<Value>(&value) {
+            Ok(v) => {
+                let property_map = unwrap_or_return!(
+                    v.as_object(),
+                    value,
+                    "Could not parse value as JSON object");
+
+                let selected_property = unwrap_or_return!(
+                    property_map.iter().find(|(k, _)| k != &METADATA_KEY),
+                    value,
+                    "Could not find a property not called {METADATA_KEY}");
+
+                let metadata_descriptor = if property_map.contains_key(&METADATA_KEY.to_string()) {
+                    "has"
+                } else {
+                    "doesn't have"
+                };
+
+                debug!(
+                    "Value contained {} properties and {metadata_descriptor} a $metadata property. Selecting property with key {} as the signal value",
+                    property_map.len(),
+                    selected_property.0
+                );
+
+                match selected_property.1 {
+                    Value::String(s) => s.clone(),
+                    _ => {
+                        warn!("Property did not have a string value");
+                        value
+                    }
+                }
+            },
+            Err(e) => {
+                warn!("Failed to parse value: {e}");
+                value
+            }
+        }
     }
 }
 
@@ -40,14 +110,7 @@ impl DigitalTwinConsumer for GRPCClientImpl {
 
         debug!("Received a publish for entity id {entity_id} with the value {value}");
 
-        let deserialize_result = serde_json::from_str::<Value>(value);
-
-        let value = match deserialize_result {
-            Ok(v) => {
-                // Get the first property not called "$metadata" and assume that's the correct property
-                let foo = v.as_object()
-            }
-        }
+        let value = Self::parse_value(value);
 
         let new_signal_value = SignalValue { entity_id, value };
         self.signal_values_queue.push(new_signal_value);
@@ -70,7 +133,7 @@ impl DigitalTwinConsumer for GRPCClientImpl {
 }
 
 #[cfg(test)]
-mod consumer_impl_tests {
+mod grpc_client_impl_tests {
     use super::*;
 
     #[tokio::test]
@@ -85,5 +148,54 @@ mod consumer_impl_tests {
         let request = tonic::Request::new(PublishRequest { entity_id, value });
         let result = consumer_impl.publish(request).await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parse_value_returns_input_when_parse_fails() {
+        let input = r#"invalid json"#;
+        let result = GRPCClientImpl::parse_value(input.to_string());
+
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn parse_value_returns_input_when_input_is_plain_string() {
+        let input = r#""value""#;
+        let result = GRPCClientImpl::parse_value(input.to_string());
+
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn parse_value_returns_input_when_input_has_zero_properties() {
+        let input = r#"{}"#;
+        let result = GRPCClientImpl::parse_value(input.to_string());
+
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn parse_value_returns_input_when_input_has_no_valid_properties() {
+        let input = format!(r#"{{"{METADATA_KEY}": "foo"}}"#);
+        let result = GRPCClientImpl::parse_value(input.to_string());
+
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn parse_value_returns_input_when_property_value_is_not_string() {
+        let input = r#"{"property": ["value"]}"#;
+        let result = GRPCClientImpl::parse_value(input.to_string());
+
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn parse_value_returns_correct_value() {
+        let expected_value = "value";
+        let input = format!(r#"{{"property": "{expected_value}", "{METADATA_KEY}": "foo"}}"#);
+        let result = GRPCClientImpl::parse_value(input.to_string());
+
+        assert_eq!(result, expected_value);
     }
 }

--- a/provider_proxies/grpc/v1/src/grpc_client_impl.rs
+++ b/provider_proxies/grpc/v1/src/grpc_client_impl.rs
@@ -26,13 +26,13 @@ macro_rules! unwrap_or_return {
                 return $ret;
             }
         }
-    }
+    };
 }
 
 /// Struct which implements the DigitalTwinConsumer trait for GRPC clients
 #[derive(Debug, Default)]
 pub struct GRPCClientImpl {
-    /// The queue on which incoming signal values shoudl be published
+    /// The queue on which incoming signal values should be published
     pub signal_values_queue: Arc<SegQueue<SignalValue>>,
 }
 
@@ -40,33 +40,32 @@ impl GRPCClientImpl {
     /// Parses the value published by a provider.
     /// The current implementation is a workaround for the current Ibeji sample provider implementation,
     /// which uses a non-consistent contract as follows:
-    /// 
+    ///
     /// ```ignore
     /// {
     ///     "{propertyName}": "value",
     ///     "$metadata": {...}
     /// }
     /// ```
-    /// 
+    ///
     /// Note that `{propertyName}` is replaced by the name of the property that the provider published.
     /// This method assumes that the first property not called `$metadata` is the one we're interested in,
     /// and will attempt to extract and return the value of that property.
     /// If any part of parsing fails, a warning is logged and the original value is returned.
-    /// 
+    ///
     /// # Arguments
     /// - `value`: the value to attempt to parse
     fn parse_value(value: String) -> String {
         match serde_json::from_str::<Value>(&value) {
             Ok(v) => {
-                let property_map = unwrap_or_return!(
-                    v.as_object(),
-                    value,
-                    "Could not parse value as JSON object");
+                let property_map =
+                    unwrap_or_return!(v.as_object(), value, "Could not parse value as JSON object");
 
                 let selected_property = unwrap_or_return!(
                     property_map.iter().find(|(k, _)| k != &METADATA_KEY),
                     value,
-                    "Could not find a property not called {METADATA_KEY}");
+                    "Could not find a property not called {METADATA_KEY}"
+                );
 
                 let metadata_descriptor = if property_map.contains_key(&METADATA_KEY.to_string()) {
                     "has"
@@ -87,7 +86,7 @@ impl GRPCClientImpl {
                         value
                     }
                 }
-            },
+            }
             Err(e) => {
                 warn!("Failed to parse value: {e}");
                 value

--- a/provider_proxies/grpc/v1/src/grpc_client_impl.rs
+++ b/provider_proxies/grpc/v1/src/grpc_client_impl.rs
@@ -225,6 +225,15 @@ mod grpc_client_impl_tests {
     }
 
     #[test]
+    fn parse_value_skips_metadata_property() {
+        let expected_value = "value";
+        let input = format!(r#"{{"{METADATA_KEY}": "foo", "property": "{expected_value}"}}"#);
+        let result = GRPCClientImpl::parse_value(input.to_string());
+
+        assert_eq!(result, expected_value);
+    }
+
+    #[test]
     fn parse_value_skips_non_primitive_properties() {
         let expected_value = "value";
         let input = format!(r#"{{"foo": ["bar"], "property": "{expected_value}", "{METADATA_KEY}": "foo"}}"#);

--- a/provider_proxies/grpc/v1/src/grpc_client_impl.rs
+++ b/provider_proxies/grpc/v1/src/grpc_client_impl.rs
@@ -40,7 +40,7 @@ impl GRPCClientImpl {
     /// This function will extract the value from the first property satisfying the following conditions:
     /// - The property is not named `$metadata`
     /// - The property value is a non-null primitive JSON type (string, bool, or number)
-    /// 
+    ///
     /// If any part of parsing fails, a warning is logged and the original value is returned.
     ///
     /// # Arguments
@@ -74,12 +74,13 @@ impl GRPCClientImpl {
                 }
 
                 match selected_property {
-                    Some((k,v)) => {
-                        let metadata_descriptor = if property_map.contains_key(&METADATA_KEY.to_string()) {
-                            "has"
-                        } else {
-                            "doesn't have"
-                        };
+                    Some((k, v)) => {
+                        let metadata_descriptor =
+                            if property_map.contains_key(&METADATA_KEY.to_string()) {
+                                "has"
+                            } else {
+                                "doesn't have"
+                            };
 
                         debug!(
                             "Value contained {} properties and {metadata_descriptor} a $metadata property. Selecting property with key {} as the signal value",
@@ -88,7 +89,7 @@ impl GRPCClientImpl {
                         );
 
                         v
-                    },
+                    }
                     None => {
                         warn!("Could not find a property that was parseable as a value");
                         value
@@ -236,7 +237,9 @@ mod grpc_client_impl_tests {
     #[test]
     fn parse_value_skips_non_primitive_properties() {
         let expected_value = "value";
-        let input = format!(r#"{{"foo": ["bar"], "property": "{expected_value}", "{METADATA_KEY}": "foo"}}"#);
+        let input = format!(
+            r#"{{"foo": ["bar"], "property": "{expected_value}", "{METADATA_KEY}": "foo"}}"#
+        );
         let result = GRPCClientImpl::parse_value(input.to_string());
 
         assert_eq!(result, expected_value);


### PR DESCRIPTION
The contract for the providers that the GRPC provider proxy was implemented against changed with https://github.com/eclipse-ibeji/ibeji/pull/35 . This change was not initially detected because it doesn't cause errors with Freyja, and they were only visible when running with the cloud connector.

The old contract for the providers in the mixed sample was to publish raw values as strings.

The new contract is to publish a serialized JSON blob which does not have a consistent schema. This workaround relies on the structure of that response and checks for a property not named `$metadata`, which is common to all of the publishes from the mixed provider. The implementation also contains fallbacks so that the old contract is still compatible.

The ideal solution still needs some design work, but likely involves an update to #19 which makes schemas pluggable separately from protocols, then a pluggable schema component in the examples repo for this Ibeji sample