### PR TITLE
Add retry logic to cartographer for mappings which can't be tracked on the first attempt

### DIFF
--- a/common/src/signal_store.rs
+++ b/common/src/signal_store.rs
@@ -43,7 +43,7 @@ impl SignalStore {
     /// - If the incoming signal is not in the data store, create a new signal from the patch.
     ///
     /// # Arguments
-    /// - `incoming_signals`: The signal patches to use to generate the new signal
+    /// - `incoming_signals`: The signal patches used to generate the new signal
     pub fn add<SyncIterator, IntoSignalPatch>(&self, incoming_signals: SyncIterator)
     where
         SyncIterator: Iterator<Item = IntoSignalPatch>,

--- a/freyja/src/cartographer.rs
+++ b/freyja/src/cartographer.rs
@@ -107,7 +107,7 @@ impl<
                         Err(e) => log::error!("Failed to get mapping from mapping client: {e}"),
                     }
                 }
-                Ok(_) if failed_attempts.len() > 0 => {
+                Ok(_) if !failed_attempts.is_empty() => {
                     info!("No new mappings found, but some mappings failed to be created in previous iterations");
 
                     // Retry previously failed attempts
@@ -137,7 +137,7 @@ impl<
     /// - `failures`: the list to update with failed signals
     async fn process_signal_patches(
         &self,
-        patches: &Vec<SignalPatch>,
+        patches: &[SignalPatch],
         successes: &mut Vec<SignalPatch>,
         failures: &mut Vec<SignalPatch>,
     ) {

--- a/freyja/src/cartographer.rs
+++ b/freyja/src/cartographer.rs
@@ -98,7 +98,7 @@ impl<
                     match self.get_mapping_as_signal_patches().await {
                         Ok(p) => {
                             // We clear the failed attempts here because the incoming mapping is used as the source of truth,
-                            // so anything lect over from previous mappings shouldn't get used.
+                            // so anything left over from previous mappings shouldn't get used.
                             failed_attempts.clear();
                             self.process_signal_patches(&p, &mut successes, &mut failed_attempts)
                                 .await;

--- a/mocks/mock_digital_twin/res/mock_digital_twin_config.default.json
+++ b/mocks/mock_digital_twin/res/mock_digital_twin_config.default.json
@@ -5,7 +5,7 @@
             "begin": 1,
             "end": null,
             "entity": {
-                "id": "dtmi:sdv:Vehicle:Cabin:HVAC:AmbientAirTemperature;1",
+                "id": "dtmi:sdv:HVAC:AmbientAirTemperature;1",
                 "name": "AmbientAirTemperature",
                 "description": "The immediate surroundings air temperature (in Fahrenheit).",
                 "endpoints": [
@@ -25,7 +25,7 @@
             "begin": 2,
             "end": null,
             "entity": {
-                "id": "dtmi:sdv:Vehicle:Cabin:HVAC:IsAirConditioningActive;1",
+                "id": "dtmi:sdv:HVAC:IsAirConditioningActive;1",
                 "name": "IsAirConditioningActive",
                 "description": "Is air conditioning active?",
                 "endpoints": [
@@ -45,7 +45,7 @@
             "begin": 3,
             "end": null,
             "entity": {
-                "id": "dtmi:sdv:Vehicle:OBD:HybridBatteryRemaining;1",
+                "id": "dtmi:sdv:OBD:HybridBatteryRemaining;1",
                 "name": "HybridBatteryRemaining",
                 "description": "Percentage of the hybrid battery remaining",
                 "endpoints": [

--- a/mocks/mock_digital_twin/src/main.rs
+++ b/mocks/mock_digital_twin/src/main.rs
@@ -254,7 +254,8 @@ async fn get_entity(
             ok!(FindByIdResponse {
                 entity: config_item.entity.clone()
             })
-        }).unwrap_or(not_found!())
+        })
+        .unwrap_or(not_found!())
 }
 
 /// Handles subscribe requests to an entity

--- a/mocks/mock_digital_twin/src/main.rs
+++ b/mocks/mock_digital_twin/src/main.rs
@@ -254,8 +254,7 @@ async fn get_entity(
             ok!(FindByIdResponse {
                 entity: config_item.entity.clone()
             })
-        })
-        .unwrap_or(not_found!())
+        }).unwrap_or(not_found!())
 }
 
 /// Handles subscribe requests to an entity


### PR DESCRIPTION
Add retry logic to cartographer for mappings which can't be tracked on the first attempt. This addresses the scenario where a provider starts up after a mapping is requested for that provider, which is being utilized in the blueprint