### PR TITLE
Make interactivity optional for mocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "freyja-contracts",
  "home",
  "log",
+ "proc-macros",
  "serde",
  "serde_json",
  "tokio",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,6 +13,7 @@ config = { workspace = true }
 freyja-contracts = { workspace = true }
 home = { workspace = true }
 log = { workspace = true }
+proc-macros = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/common/src/cmd_utils.rs
+++ b/common/src/cmd_utils.rs
@@ -31,11 +31,12 @@ where
     for arg in args.skip(1) {
         let mut split = arg.split('=');
         let key = match split.next() {
+            // Note that unwrapping here will always succeed because `s` is guaranteed to be at least 3 chars long
             Some(s) if s.len() > 2 && s.get(..2) == Some("--") => s.get(2..).unwrap().to_owned(),
             _ => return Err(ParseArgsErrorKind::KeyParseError { arg }.into()),
         };
 
-        // If split.next() returns None, then this was a flag argument and the map also returns None.
+        // If split.next() returns None, then this was a flag argument and the call to map also returns None.
         let val = split.next().map(|v| v.to_owned());
 
         if split.next().is_some() {

--- a/common/src/cmd_utils.rs
+++ b/common/src/cmd_utils.rs
@@ -8,10 +8,7 @@ use log::LevelFilter;
 use proc_macros::error;
 
 /// Gets the command-line arguments.
-/// Arguments should be formatted in the following way:
-///
-///     --key[=value]
-///
+/// Arguments should be formatted as `--key[=value]`.
 /// The output is a `HashMap` containing keys mapped to values.
 /// The keys have all leading `-` characters removed.
 /// If an argument is passed as a flag without a corresponding value,

--- a/common/src/cmd_utils.rs
+++ b/common/src/cmd_utils.rs
@@ -1,0 +1,264 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT/
+
+use std::{collections::HashMap, str::FromStr};
+
+use log::LevelFilter;
+use proc_macros::error;
+
+/// Gets the command-line arguments.
+/// Arguments should be formatted in the following way:
+///
+///     --key[=value]
+///
+/// The output is a `HashMap` containing keys mapped to values.
+/// The keys have all leading `-` characters removed.
+/// If an argument is passed as a flag without a corresponding value,
+/// then an entry is created in the hash map with a value of `None`.
+/// Note that this does not support values containing the `=` character,
+/// nor does it support multiple instances of the same key!
+///
+/// # Arguments
+/// - `args`: the command-line arguments (usually obtained with `env::args()`)
+pub fn parse_args<T>(args: T) -> Result<HashMap<String, Option<String>>, ParseArgsError>
+where
+    T: Iterator<Item = String>,
+{
+    let mut result = HashMap::new();
+
+    // First item in this list is the program name
+    for arg in args.skip(1) {
+        let mut split = arg.split("=");
+        let key = match split.next() {
+            Some(s) if s.len() > 2 && s.get(..2) == Some("--") => s.get(2..).unwrap().to_owned(),
+            _ => return Err(ParseArgsErrorKind::KeyParseError { arg }.into()),
+        };
+
+        // If split.next() returns None, then this was a flag argument and the map also returns None.
+        let val = split.next().map(|v| v.to_owned());
+
+        if split.next().is_some() {
+            return Err(ParseArgsErrorKind::ValueParseError { arg }.into());
+        }
+
+        if result.contains_key(&key) {
+            return Err(ParseArgsErrorKind::DuplicateKeys { key }.into());
+        }
+
+        result.insert(key, val);
+    }
+
+    Ok(result)
+}
+
+/// Gets the log level from the provided args.
+/// Returns `ParseError` if the argument could not be parsed into a `LevelFilter`,
+/// and `MissingValue` if a log level argument was present but did not specify a value.
+///
+/// # Arguments
+/// - `args`: the parsed command line arguments.
+/// - `default`: the default value to use if there is no log-level argument.
+pub fn get_log_level(
+    args: &HashMap<String, Option<String>>,
+    default: LevelFilter,
+) -> Result<LevelFilter, GetLogLevelError> {
+    match args.get("log-level") {
+        Some(Some(l)) => LevelFilter::from_str(l)
+            .map_err(|_| GetLogLevelErrorKind::ParseError { val: l.to_owned() }.into()),
+        Some(None) => Err(GetLogLevelErrorKind::MissingValue.into()),
+        None => Ok(default),
+    }
+}
+
+error! {
+    ParseArgsError {
+        KeyParseError {
+            arg: String
+        },
+        ValueParseError {
+            arg: String
+        },
+        DuplicateKeys {
+            key: String
+        },
+    }
+}
+
+error! {
+    GetLogLevelError {
+        MissingValue,
+        ParseError {
+            val: String
+        },
+    }
+}
+
+#[cfg(test)]
+mod cmd_utils_tests {
+    use super::*;
+
+    #[test]
+    fn parse_args_parses_valid_input() {
+        let cmd = "cmd".to_owned();
+        let key = "foo".to_owned();
+        let val = "bar".to_owned();
+        let flag = "flag".to_owned();
+
+        let input = vec![
+            // Mimics the behavior of real command-line args which have the command as the first entry.
+            cmd.clone(),
+            format!("--{key}={val}"),
+            format!("--{flag}"),
+        ];
+
+        let result = parse_args(input.into_iter());
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result.get(&key), Some(&Some(val)));
+        assert_eq!(result.get(&flag), Some(&None));
+        assert!(!result.contains_key("dne"));
+        assert!(!result.contains_key(&cmd));
+    }
+
+    #[test]
+    fn parse_args_returns_error_when_arg_too_short() {
+        let cmd = "cmd".to_owned();
+        let invalid_arg = "1".to_owned();
+
+        let input = vec![
+            // Mimics the behavior of real command-line args which have the command as the first entry.
+            cmd.clone(),
+            invalid_arg.clone(),
+        ];
+
+        let result = parse_args(input.into_iter());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err.kind() {
+            ParseArgsErrorKind::KeyParseError { arg } => assert_eq!(arg, invalid_arg),
+            _ => panic!("Expected KeyParseError"),
+        }
+    }
+
+    #[test]
+    fn parse_args_returns_error_when_arg_missing_dashes() {
+        let cmd = "cmd".to_owned();
+        let invalid_arg = "arg".to_owned();
+
+        let input = vec![
+            // Mimics the behavior of real command-line args which have the command as the first entry.
+            cmd.clone(),
+            invalid_arg.clone(),
+        ];
+
+        let result = parse_args(input.into_iter());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err.kind() {
+            ParseArgsErrorKind::KeyParseError { arg } => assert_eq!(arg, invalid_arg),
+            _ => panic!("Expected KeyParseError"),
+        }
+    }
+
+    #[test]
+    fn parse_args_returns_error_when_too_many_equals() {
+        let cmd = "cmd".to_owned();
+        let invalid_arg = "--key=foo=bar".to_owned();
+
+        let input = vec![
+            // Mimics the behavior of real command-line args which have the command as the first entry.
+            cmd.clone(),
+            invalid_arg.clone(),
+        ];
+
+        let result = parse_args(input.into_iter());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err.kind() {
+            ParseArgsErrorKind::ValueParseError { arg } => assert_eq!(arg, invalid_arg),
+            _ => panic!("Expected ValueParseError"),
+        }
+    }
+
+    #[test]
+    fn parse_args_returns_error_when_duplicate_keys() {
+        let cmd = "cmd".to_owned();
+        let dup_key = "key".to_owned();
+
+        let input = vec![
+            // Mimics the behavior of real command-line args which have the command as the first entry.
+            cmd.clone(),
+            format!("--{dup_key}"),
+            format!("--{dup_key}"),
+        ];
+
+        let result = parse_args(input.into_iter());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err.kind() {
+            ParseArgsErrorKind::DuplicateKeys { key } => assert_eq!(key, dup_key),
+            _ => panic!("Expected DuplicateKeys"),
+        }
+    }
+
+    #[test]
+    fn get_log_level_returns_value() {
+        let mut args = HashMap::new();
+        args.insert("log-level".to_owned(), Some("debug".to_owned()));
+
+        let result = get_log_level(&args, LevelFilter::Info);
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result, LevelFilter::Debug);
+    }
+
+    #[test]
+    fn get_log_level_returns_parse_error() {
+        let mut args = HashMap::new();
+        let invalid_value = "foo".to_owned();
+        args.insert("log-level".to_owned(), Some(invalid_value.clone()));
+
+        let result = get_log_level(&args, LevelFilter::Info);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err.kind() {
+            GetLogLevelErrorKind::ParseError { val } => assert_eq!(val, invalid_value),
+            _ => panic!("Expected ParseError"),
+        }
+    }
+
+    #[test]
+    fn get_log_level_returns_missing_value() {
+        let mut args = HashMap::new();
+        args.insert("log-level".to_owned(), None);
+
+        let result = get_log_level(&args, LevelFilter::Info);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        match err.kind() {
+            GetLogLevelErrorKind::MissingValue => {}
+            _ => panic!("Expected MissingValue"),
+        }
+    }
+
+    #[test]
+    fn get_log_level_returns_default() {
+        let args = HashMap::new();
+        let default = LevelFilter::Info;
+
+        let result = get_log_level(&args, default);
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result, default);
+    }
+}

--- a/common/src/cmd_utils.rs
+++ b/common/src/cmd_utils.rs
@@ -36,7 +36,7 @@ where
             _ => return Err(ParseArgsErrorKind::KeyParseError { arg }.into()),
         };
 
-        // If split.next() returns None, then this was a flag argument and the call to map also returns None.
+        // If split.next() returns None here, then this was a flag argument and the call to map also returns None.
         let val = split.next().map(|v| v.to_owned());
 
         if split.next().is_some() {

--- a/common/src/cmd_utils.rs
+++ b/common/src/cmd_utils.rs
@@ -29,7 +29,7 @@ where
 
     // First item in this list is the program name
     for arg in args.skip(1) {
-        let mut split = arg.split("=");
+        let mut split = arg.split('=');
         let key = match split.next() {
             Some(s) if s.len() > 2 && s.get(..2) == Some("--") => s.get(2..).unwrap().to_owned(),
             _ => return Err(ParseArgsErrorKind::KeyParseError { arg }.into()),

--- a/common/src/cmd_utils.rs
+++ b/common/src/cmd_utils.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-// SPDX-License-Identifier: MIT/
+// SPDX-License-Identifier: MIT
 
 use std::{collections::HashMap, str::FromStr};
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
+pub mod cmd_utils;
 pub mod config_utils;
 pub mod message_utils;
 pub mod retry_utils;

--- a/freyja/src/lib.rs
+++ b/freyja/src/lib.rs
@@ -56,7 +56,7 @@ pub async fn freyja_main<
         .collect();
 
     // Setup logging
-    let log_level = LevelFilter::from_str(args.get("log-level").unwrap_or(&"info".to_owned()))
+    let log_level = LevelFilter::from_str(args.get("--log-level").unwrap_or(&"info".to_owned()))
         .expect("Could not parse log level");
     env_logger::Builder::new()
         .filter(None, log_level)

--- a/freyja/src/lib.rs
+++ b/freyja/src/lib.rs
@@ -4,20 +4,23 @@
 
 // Re-export this macro for convenience so users don't need to manually import the proc_macros crate
 pub use proc_macros::freyja_main;
-use tokio::sync::Mutex;
 
 mod cartographer;
 mod emitter;
 
-use std::{collections::HashMap, env, str::FromStr, sync::Arc, time::Duration};
+use std::{env, sync::Arc, time::Duration};
 
 use crossbeam::queue::SegQueue;
 use env_logger::Target;
 use log::LevelFilter;
+use tokio::sync::Mutex;
 
 use cartographer::Cartographer;
 use emitter::Emitter;
-use freyja_common::signal_store::SignalStore;
+use freyja_common::{
+    cmd_utils::{get_log_level, parse_args},
+    signal_store::SignalStore,
+};
 use freyja_contracts::{
     cloud_adapter::CloudAdapter, digital_twin_adapter::DigitalTwinAdapter,
     mapping_client::MappingClient, provider_proxy::SignalValue,
@@ -36,29 +39,10 @@ pub async fn freyja_main<
     TCloudAdapter: CloudAdapter,
     TMappingClient: MappingClient,
 >() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let args: HashMap<String, String> = env::args()
-        .skip(1)
-        .map(|arg| {
-            let mut split = arg.split('=');
-            let key = split
-                .next()
-                .expect("Couldn't parse argument key")
-                .to_owned();
-            let val = split
-                .next()
-                .expect("Couldn't parse argument value")
-                .to_owned();
-            if split.next().is_some() {
-                panic!("Too many pieces in argument");
-            }
-
-            (key, val)
-        })
-        .collect();
+    let args = parse_args(env::args()).expect("Failed to parse args");
 
     // Setup logging
-    let log_level = LevelFilter::from_str(args.get("--log-level").unwrap_or(&"info".to_owned()))
-        .expect("Could not parse log level");
+    let log_level = get_log_level(&args, LevelFilter::Info).expect("Could not parse log level");
     env_logger::Builder::new()
         .filter(None, log_level)
         .target(Target::Stdout)

--- a/mocks/mock_digital_twin/README.md
+++ b/mocks/mock_digital_twin/README.md
@@ -23,10 +23,26 @@ This mock supports [config overrides](../../docs/config-overrides.md). The overr
 
 ## Behavior
 
-The application maintains an internal count, and only entities satisfying the condition `begin <= count [< end]` will be enabled for all APIs. To increment this count and potentially change the set of enabled entities, press <kbd>Enter</kbd> in the application's console. This allows manual control over when the entities are turned on or off and permits straightforward mocking of more complex scenarios. As a result of this behavior, it is recommended to write configs such that a state change happens each time enter is pressed. For example, if a mock scenario has `n` different desired states, then all numbers in the range `0..n-1` should appear as values for at least one `begin` or `end` property. Otherwise pressing <kbd>Enter</kbd> will sometimes have no effect.
+This mock service mocks the behavior of both the Ibeji digital twin service and providers that register with it.
 
-In addition, the mock also maintains a count of the number of times each provider has been invoked, and returns a value that is a function of this count. In this way, the behavior of the `generate_signal_value()` API is identical to that of the In-Memory Provider Proxy.
+This mock exposes the `/entity` endpoint which fulfills the `find_by_id` API.
 
-Entities that support the `Subscribe` operation will allow clients to send a request to the `/providers/subscribe/{provider_id}` endpoint, and the server will periodically publish the entity values to the provided callback. The communication protocol used by these mocked providers for this callback is HTTP.
+Entities that support the `Subscribe` operation will allow clients to send a request to the `/subscribe` endpoint, and the server will periodically publish the entity values to the provided callback. The communication protocol used by these mocked providers for this callback is HTTP.
 
-Similarly, providers that support the `Get` operation will allow clients to send a request to the `/providers/get/{provider_id}` endpoint. The server will publish the entity values a single time to the provided callback rather than setting up a recurring callback. If the client wishes to retrieve the values again, then the client would need to send another request.
+Similarly, providers that support the `Get` operation will allow clients to send a request to the `/request-value` endpoint. The server will publish the entity values a single time to the provided callback rather than setting up a recurring callback. If the client wishes to retrieve the values again, then the client would need to send another request.
+
+This mock maintains a count of the number of times the value of entity has been requested, and returns a value that is a function of this count. In this way, the behavior of the `generate_signal_value()` API is identical to that of the In-Memory Provider Proxy.
+
+### Interactive Mode
+
+To use interactive mode, pass the `--interactive` argument when running the application.
+
+In interactive mode, the application maintains an internal count, and only entities satisfying the condition `begin <= count [< end]` will be enabled for all APIs. To increment this count and potentially change the set of enabled entities, press <kbd>Enter</kbd> in the application's console. This allows manual control over when the entities are turned on or off and permits straightforward mocking of more complex scenarios. As a result of this behavior, it is recommended to write configs such that a state change happens each time <kbd>Enter</kbd> is pressed. For example, if a mock scenario has `n` different desired states, then all numbers in the range `0..n-1` should appear as values for at least one `begin` or `end` property. Otherwise pressing <kbd>Enter</kbd> will sometimes have no effect.
+
+**Do not use interactive mode if running this service in a container!** This feature is not compatible with containerization and will cause unexpected behavior and very high resource consumption.
+
+### Non-Interactive Mode
+
+In non-interactive mode, the `begin` and `end` properties in the config are ignored, and all configured entities are always exposed in the mock's APIs.
+
+This is the default behavior of this application.

--- a/mocks/mock_digital_twin/README.md
+++ b/mocks/mock_digital_twin/README.md
@@ -39,7 +39,7 @@ To use interactive mode, pass the `--interactive` argument when running the appl
 
 In interactive mode, the application maintains an internal count, and only entities satisfying the condition `begin <= count [< end]` will be enabled for all APIs. To increment this count and potentially change the set of enabled entities, press <kbd>Enter</kbd> in the application's console. This allows manual control over when the entities are turned on or off and permits straightforward mocking of more complex scenarios. As a result of this behavior, it is recommended to write configs such that a state change happens each time <kbd>Enter</kbd> is pressed. For example, if a mock scenario has `n` different desired states, then all numbers in the range `0..n-1` should appear as values for at least one `begin` or `end` property. Otherwise pressing <kbd>Enter</kbd> will sometimes have no effect.
 
-**Do not use interactive mode if running this service in a container!** This feature is not compatible with containerization and will cause unexpected behavior and very high resource consumption.
+**Do not use interactive mode if running this service in a container!** This feature is not compatible with containers and will cause unexpected behavior, including very high resource consumption.
 
 ### Non-Interactive Mode
 

--- a/mocks/mock_digital_twin/src/main.rs
+++ b/mocks/mock_digital_twin/src/main.rs
@@ -6,7 +6,6 @@ mod config;
 
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::{io, net::SocketAddr, thread, time::Duration};
 
@@ -14,6 +13,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{extract, extract::State, Json, Router, Server};
 use env_logger::Target;
+use freyja_common::cmd_utils::{get_log_level, parse_args};
 use log::{debug, error, info, warn, LevelFilter};
 use reqwest::Client;
 use serde::Deserialize;
@@ -85,37 +85,16 @@ macro_rules! server_error {
 /// - An HTTP listener to accept incoming requests
 #[tokio::main]
 async fn main() {
-    let args: HashMap<String, Option<String>> = env::args()
-        .skip(1)
-        .map(|arg| {
-            let mut split = arg.split('=');
-            let key = split
-                .next()
-                .expect("Couldn't parse argument key")
-                .to_owned();
-            let val = split.next().map(|v| v.to_owned());
-
-            if split.next().is_some() {
-                panic!("Too many pieces in argument");
-            }
-
-            (key, val)
-        })
-        .collect();
+    let args = parse_args(env::args()).expect("Failed to parse args");
 
     // Setup logging
-    let log_level = args.get("--log-level")
-        .cloned()
-        .unwrap_or(Some(String::from("info")))
-        .expect("No log-level value provided");
-    let log_level = LevelFilter::from_str(log_level.as_str())
-        .expect("Could not parse log level");
+    let log_level = get_log_level(&args, LevelFilter::Info).expect("Could not parse log level");
     env_logger::Builder::new()
         .filter(None, log_level)
         .target(Target::Stdout)
         .init();
 
-    let interactive = args.get("--interactive").is_some();
+    let interactive = args.get("interactive").is_some();
 
     let config: Config = config_utils::read_from_files(
         config_file_stem!(),
@@ -157,7 +136,7 @@ async fn main() {
             let mut buffer = String::new();
             loop {
                 io::stdin().read_line(&mut buffer)?;
-    
+
                 let mut state = console_listener_state.lock().unwrap();
                 state.count += 1;
                 info!(
@@ -356,10 +335,11 @@ async fn request_value(
 /// - `end`: the end of a boundary
 /// - `interactive`: whether or not the application is running in interactive mode
 fn within_bounds(value: u8, begin: u8, end: Option<u8>, interactive: bool) -> bool {
-    !interactive || match end {
-        Some(end) => value >= begin && value < end,
-        None => value >= begin,
-    }
+    !interactive
+        || match end {
+            Some(end) => value >= begin && value < end,
+            None => value >= begin,
+        }
 }
 
 /// Gets active entity names for this mock provider
@@ -371,7 +351,12 @@ fn get_active_entity_names(state: &DigitalTwinAdapterState) -> Vec<String> {
         .entities
         .iter()
         .filter_map(|(config_item, _)| {
-            if within_bounds(state.count, config_item.begin, config_item.end, state.interactive) {
+            if within_bounds(
+                state.count,
+                config_item.begin,
+                config_item.end,
+                state.interactive,
+            ) {
                 Some(
                     config_item
                         .entity
@@ -398,7 +383,14 @@ fn find_entity<'a>(
     state
         .entities
         .iter()
-        .filter(|(config_item, _)| within_bounds(state.count, config_item.begin, config_item.end, state.interactive))
+        .filter(|(config_item, _)| {
+            within_bounds(
+                state.count,
+                config_item.begin,
+                config_item.end,
+                state.interactive,
+            )
+        })
         .find(|(config_item, _)| config_item.entity.id == *id)
 }
 
@@ -412,7 +404,9 @@ fn get_entity_value(state: &mut DigitalTwinAdapterState, id: &str) -> Option<Str
     state
         .entities
         .iter_mut()
-        .filter(|(config_item, _)| within_bounds(n, config_item.begin, config_item.end, state.interactive))
+        .filter(|(config_item, _)| {
+            within_bounds(n, config_item.begin, config_item.end, state.interactive)
+        })
         .find(|(config_item, _)| config_item.entity.id == *id)
         .map(|p| {
             p.1 += 1;

--- a/mocks/mock_mapping_service/README.md
+++ b/mocks/mock_mapping_service/README.md
@@ -8,11 +8,13 @@ The mock's default config is located at  `res/mock_mapping_config.default.json` 
 
 ## Behavior
 
-The behavior of the Mock Mapping Service is largely equivalent to that of the In-Memory Mock Mapping Client linked above, but the count is managed differently depending on which mode the application is running in.
+The behavior of the Mock Mapping Service is largely equivalent to that of the In-Memory Mock Mapping Client linked above, but the count is managed differently depending on whether the application is in interactive mode or not.
 
 ### Interactive Mode
 
 In interactive mode, the application maintains an internal count, and only mappings satisfying the condition `begin <= count [< end]` will be returned in the `/mapping` API. Unlike the in-memory client, the internal count is not updated based on how often certain APIs are called but rather by user interaction with the terminal. To increment the application's internal count and potentially change the set of enabled mappings, press <kbd>Enter</kbd> in the application's terminal window. This allows manual control over when the mappings are turned on or off and permits straightforward mocking of more complex scenarios. As a result of this behavior, it is recommended to write configs such that a state change happens each time <kbd>Enter</kbd> is pressed. For example, if a mock scenario has `n` different desired states, then all numbers in the range `0..n-1` should appear as values for at least one `begin` or `end` property. Otherwise pressing <kbd>Enter</kbd> will sometimes have no effect.
+
+**Do not use interactive mode if running this service in a container!** This feature is not compatible with containers and will cause unexpected behavior, including very high resource consumption.
 
 ### Non-Interactive Mode
 

--- a/mocks/mock_mapping_service/README.md
+++ b/mocks/mock_mapping_service/README.md
@@ -8,6 +8,14 @@ The mock's default config is located at  `res/mock_mapping_config.default.json` 
 
 ## Behavior
 
-The behavior of the Mock Mapping Service is largely identical to that of the In-Memory Mock Mapping Client linked above. The one notable exception is that the internal count is not updated based on how often certain APIs are called but rather by user interaction with the terminal. To increment the application's internal count and potentially change the set of enabled mappings, press <kbd>Enter</kbd> in the application's terminal window.
+The behavior of the Mock Mapping Service is largely equivalent to that of the In-Memory Mock Mapping Client linked above, but the count is managed differently depending on which mode the application is running in.
 
-The application maintains an internal count, and only mappings satisfying the condition `begin <= count [< end]` will be returned in the `/mapping` API. To increment this count and potentially change the set of enabled mappings, press enter in the application's console. This allows manual control over when the mappings are turned on or off and permits straightforward mocking of more complex scenarios. As a result of this behavior, it is recommended to write configs such that a state change happens each time enter is pressed. For example, if a mock scenario has `n` different desired states, then all numbers in the range `0..n-1` should appear as values for at least one `begin` or `end` property. Otherwise pressing <kbd>Enter</kbd> will sometimes have no effect.
+### Interactive Mode
+
+In interactive mode, the application maintains an internal count, and only mappings satisfying the condition `begin <= count [< end]` will be returned in the `/mapping` API. Unlike the in-memory client, the internal count is not updated based on how often certain APIs are called but rather by user interaction with the terminal. To increment the application's internal count and potentially change the set of enabled mappings, press <kbd>Enter</kbd> in the application's terminal window. This allows manual control over when the mappings are turned on or off and permits straightforward mocking of more complex scenarios. As a result of this behavior, it is recommended to write configs such that a state change happens each time <kbd>Enter</kbd> is pressed. For example, if a mock scenario has `n` different desired states, then all numbers in the range `0..n-1` should appear as values for at least one `begin` or `end` property. Otherwise pressing <kbd>Enter</kbd> will sometimes have no effect.
+
+### Non-Interactive Mode
+
+In non-interactive mode, the `begin` and `end` properties in the config are ignored, and all configured mappings are always exposed in the mock's APIs. Furthermore, this means that the application will indicate that there is work to consume when it starts up, but once it's been consumed there will not be any additional work.
+
+This is the default behavior of this application.


### PR DESCRIPTION
This PR makes interactivity optional for the mock services, with the default being no interactivity. This addresses an issue when using these services in a container.