### PR TITLE
Implement standard mapping adapter

### DIFF
--- a/.accepted_words.txt
+++ b/.accepted_words.txt
@@ -109,6 +109,7 @@ mailto
 ManagedSubscribeDataAdapter
 MappingAdapter
 MappingAdapterImpl
+MappingService
 markdownlint
 md
 microsoft

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "grpc-mapping-adapter"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "freyja-build-common",
+ "freyja-common",
+ "futures",
+ "log",
+ "mapping-service-proto",
+ "serde",
+ "tempfile",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tower",
+]
+
+[[package]]
 name = "grpc-service-discovery-adapter"
 version = "0.1.0"
 dependencies = [
@@ -1231,6 +1250,16 @@ dependencies = [
  "log",
  "serde",
  "tonic",
+]
+
+[[package]]
+name = "mapping-service-proto"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-build 0.11.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,12 +784,12 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "tempfile",
  "time",
  "tokio",
  "tokio-stream",
  "tonic",
  "tower",
+ "uuid",
 ]
 
 [[package]]
@@ -802,11 +802,11 @@ dependencies = [
  "freyja-common",
  "futures",
  "serde",
- "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",
  "tower",
+ "uuid",
 ]
 
 [[package]]
@@ -820,12 +820,12 @@ dependencies = [
  "log",
  "mapping-service-proto",
  "serde",
- "tempfile",
  "time",
  "tokio",
  "tokio-stream",
  "tonic",
  "tower",
+ "uuid",
 ]
 
 [[package]]
@@ -1952,11 +1952,11 @@ dependencies = [
  "log",
  "samples-protobuf-data-access",
  "serde",
- "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",
  "tower",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
 name = "mapping-service-proto"
 version = "0.1.0"
 dependencies = [
+ "freyja-common",
  "prost",
  "prost-types",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ serde_json = "1.0.113"
 strum = "0.26.1"
 strum_macros = "0.26.1"
 syn = { version = "2.0.40", features = ["extra-traits", "full"] }
-tempfile = "3.10.0"
 time = "0.3.34"
 tokio = { version = "1.36", features = ["macros", "rt-multi-thread", "time", "sync", "test-util"] }
 tokio-stream = { version = "0.1.8", features = ["net"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "adapters/digital_twin/grpc_digital_twin_adapter",
   "adapters/digital_twin/in_memory_mock_digital_twin_adapter",
   "adapters/digital_twin/mock_digital_twin_adapter",
+  "adapters/mapping/grpc_mapping_adapter",
   "adapters/mapping/in_memory_mock_mapping_adapter",
   "adapters/mapping/mock_mapping_service_adapter",
   "adapters/service_discovery/file_service_discovery_adapter",
@@ -27,6 +28,7 @@ members = [
   "mocks/mock_mapping_service",
   "proc_macros",
   "proto/cloud_connector",
+  "proto/mapping_service",
 ]
 
 [workspace.dependencies]
@@ -35,7 +37,9 @@ cloud-connector-proto = { path = "proto/cloud_connector" }
 file-service-discovery-adapter = { path = "adapters/service_discovery/file_service_discovery_adapter" }
 freyja-build-common = { path = "build_common" }
 freyja-common = { path = "common" }
+grpc-cloud-adapter = { path = "adapters/cloud/grpc_cloud_adapter" }
 grpc-digital-twin-adapter = { path = "adapters/digital_twin/grpc_digital_twin_adapter" }
+grpc-mapping-adapter = { path = "adapters/mapping/grpc_mapping_adapter" }
 grpc-service-discovery-adapter = { path = "adapters/service_discovery/grpc_service_discovery_adapter" }
 http-mock-data-adapter = { path = "adapters/data/http_mock_data_adapter" }
 in-memory-mock-cloud-adapter = { path = "adapters/cloud/in_memory_mock_cloud_adapter" }
@@ -43,6 +47,7 @@ in-memory-mock-data-adapter = { path = "adapters/data/in_memory_mock_data_adapte
 in-memory-mock-digital-twin-adapter = { path ="adapters/digital_twin/in_memory_mock_digital_twin_adapter" }
 in-memory-mock-mapping-adapter = { path = "adapters/mapping/in_memory_mock_mapping_adapter" }
 managed-subscribe-data-adapter = { path = "adapters/data/managed_subscribe_data_adapter" }
+mapping-service-proto = { path = "proto/mapping_service" }
 mock-digital-twin = { path = "mocks/mock_digital_twin" }
 mock-digital-twin-adapter = { path = "adapters/digital_twin/mock_digital_twin_adapter" }
 mock-mapping-service-adapter = { path = "adapters/mapping/mock_mapping_service_adapter" }

--- a/adapters/cloud/grpc_cloud_adapter/Cargo.toml
+++ b/adapters/cloud/grpc_cloud_adapter/Cargo.toml
@@ -23,7 +23,7 @@ tonic = { workspace = true }
 freyja-build-common = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 time = { workspace = true }
 tokio-stream = { workspace = true }
 tower = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }

--- a/adapters/cloud/grpc_cloud_adapter/README.md
+++ b/adapters/cloud/grpc_cloud_adapter/README.md
@@ -1,6 +1,6 @@
 # gRPC Cloud Adapter
 
-The gRPC Cloud Adapter is intended to function as a "standard cloud adapter", enabling integration with other services that implement the appropriate APIs. This reduces the need for custom adapter implementations and facilitates integration with non-rust solutions for other parts of the vehicle system. This library contains an implementation of the `CloudAdapter` trait from the contracts.
+The gRPC Cloud Adapter is intended to function as a "standard cloud adapter", enabling integration with other services that implement the appropriate APIs. This reduces the need for custom adapter implementations and facilitates integration with non-Rust solutions for other parts of the vehicle system. This library contains an implementation of the `CloudAdapter` trait from the contracts.
 
 ## Contract
 

--- a/adapters/cloud/grpc_cloud_adapter/res/grpc_cloud_adapter_config.default.json
+++ b/adapters/cloud/grpc_cloud_adapter/res/grpc_cloud_adapter_config.default.json
@@ -1,5 +1,5 @@
 {
     "target_uri": "http://0.0.0.0:5176",
-    "max_retries": 20,
+    "max_retries": 5,
     "retry_interval_ms": 10000
 }

--- a/adapters/data/sample_grpc_data_adapter/Cargo.toml
+++ b/adapters/data/sample_grpc_data_adapter/Cargo.toml
@@ -16,13 +16,13 @@ futures = { workspace = true }
 log = { workspace = true }
 samples-protobuf-data-access  = { workspace = true }
 serde = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
-tower = { workspace = true }
 
 [dev-dependencies]
 tokio-stream = { workspace = true }
+tower = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [build-dependencies]
 freyja-build-common = { workspace = true }

--- a/adapters/data/sample_grpc_data_adapter/src/sample_grpc_data_adapter.rs
+++ b/adapters/data/sample_grpc_data_adapter/src/sample_grpc_data_adapter.rs
@@ -268,22 +268,52 @@ mod grpc_data_adapter_tests {
 
         use super::*;
 
-        use std::sync::Arc;
+        use std::{
+            io::{stderr, Write},
+            path::PathBuf,
+            sync::Arc,
+        };
 
-        use tempfile::TempPath;
         use tokio::net::{UnixListener, UnixStream};
         use tokio_stream::wrappers::UnixListenerStream;
         use tonic::transport::{Channel, Endpoint, Server, Uri};
         use tower::service_fn;
+        use uuid::Uuid;
+
+        pub struct TestFixture {
+            pub socket_path: PathBuf,
+        }
+
+        impl TestFixture {
+            fn new() -> Self {
+                Self {
+                    socket_path: std::env::temp_dir()
+                        .as_path()
+                        .join(Uuid::new_v4().as_hyphenated().to_string()),
+                }
+            }
+        }
+
+        impl Drop for TestFixture {
+            fn drop(&mut self) {
+                match std::fs::remove_file(&self.socket_path) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        write!(stderr(), "Error cleaning up `TestFixture`: {e:?}")
+                            .expect("Error writing to stderr");
+                    }
+                }
+            }
+        }
 
         async fn create_test_grpc_client(
-            bind_path: Arc<TempPath>,
+            socket_path: PathBuf,
         ) -> DigitalTwinProviderClient<Channel> {
             let channel = Endpoint::try_from("http://URI_IGNORED") // Devskim: ignore DS137138
                 .unwrap()
                 .connect_with_connector(service_fn(move |_: Uri| {
-                    let bind_path = bind_path.clone();
-                    async move { UnixStream::connect(bind_path.as_ref()).await }
+                    let socket_path = socket_path.clone();
+                    async move { UnixStream::connect(socket_path).await }
                 }))
                 .await
                 .unwrap();
@@ -302,19 +332,14 @@ mod grpc_data_adapter_tests {
 
         #[tokio::test]
         async fn send_request_to_provider() {
+            let fixture = TestFixture::new();
+
             // Create the Unix Socket
-            let bind_path = Arc::new(tempfile::NamedTempFile::new().unwrap().into_temp_path());
-            let uds = match UnixListener::bind(bind_path.as_ref()) {
-                Ok(unix_listener) => unix_listener,
-                Err(_) => {
-                    std::fs::remove_file(bind_path.as_ref()).unwrap();
-                    UnixListener::bind(bind_path.as_ref()).unwrap()
-                }
-            };
+            let uds = UnixListener::bind(&fixture.socket_path).unwrap();
             let uds_stream = UnixListenerStream::new(uds);
 
             let request_future = async {
-                let client = create_test_grpc_client(bind_path.clone()).await;
+                let client = create_test_grpc_client(fixture.socket_path.clone()).await;
                 let grpc_data_adapter = SampleGRPCDataAdapter {
                     config: Config {
                         consumer_address: "[::1]:60010".to_string(),
@@ -371,8 +396,6 @@ mod grpc_data_adapter_tests {
                 _ = run_test_grpc_server(uds_stream) => (),
                 _ = request_future => ()
             }
-
-            std::fs::remove_file(bind_path.as_ref()).unwrap();
         }
     }
 }

--- a/adapters/digital_twin/grpc_digital_twin_adapter/Cargo.toml
+++ b/adapters/digital_twin/grpc_digital_twin_adapter/Cargo.toml
@@ -15,11 +15,13 @@ freyja-build-common = { workspace = true }
 freyja-common = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }
-tokio-stream = { workspace = true, features = ["net"] }
 tonic = { workspace = true }
-tower = { workspace = true }
 
 [build-dependencies]
 freyja-build-common = { workspace = true }
+
+[dev-dependencies]
+tokio-stream = { workspace = true, features = ["net"] }
+tower = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }

--- a/adapters/mapping/grpc_mapping_adapter/Cargo.toml
+++ b/adapters/mapping/grpc_mapping_adapter/Cargo.toml
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "grpc-mapping-adapter"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+async-trait = { workspace = true }
+mapping-service-proto = { workspace = true }
+freyja-build-common = { workspace = true }
+freyja-common = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+tonic = { workspace = true }
+
+[build-dependencies]
+freyja-build-common = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+time = { workspace = true }
+tokio-stream = { workspace = true }
+tower = { workspace = true }

--- a/adapters/mapping/grpc_mapping_adapter/Cargo.toml
+++ b/adapters/mapping/grpc_mapping_adapter/Cargo.toml
@@ -23,7 +23,7 @@ tonic = { workspace = true }
 freyja-build-common = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 time = { workspace = true }
 tokio-stream = { workspace = true }
 tower = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }

--- a/adapters/mapping/grpc_mapping_adapter/README.md
+++ b/adapters/mapping/grpc_mapping_adapter/README.md
@@ -1,10 +1,10 @@
-# gRPC Cloud Adapter
+# gRPC Mapping Adapter
 
-The gRPC Cloud Adapter is intended to function as a "standard cloud adapter", enabling integration with other services that implement the appropriate APIs. This reduces the need for custom adapter implementations and facilitates integration with non-rust solutions for other parts of the vehicle system. This library contains an implementation of the `CloudAdapter` trait from the contracts.
+The gRPC Mapping Adapter is intended to function as a "standard mapping adapter", enabling integration with other services that implement the appropriate APIs. This reduces the need for custom adapter implementations and facilitates integration with non-rust solutions for other parts of the vehicle system. This library contains an implementation of the `MappingAdapter` trait from the contracts.
 
 ## Contract
 
-This adapter utilizes a gRPC client for the `CloudConnector` service in the [cloud connector v1 protobuf description](../../../interfaces/cloud_connector/v1/cloud_connector.proto). To integrate a cloud connector with this adapter, you will need to implement a gRPC server for this service. Samples can be found in the [Ibeji Example Applications Repository](https://github.com/eclipse-ibeji/ibeji-example-applications/tree/main/cloud_connectors/).
+This adapter utilizes a gRPC client for the `MappingService` in the [mapping service v1 protobuf description](../../../interfaces/mapping_service/v1/mapping_service.proto). To integrate a mapping service with this adapter, you will need to implement a gRPC server for this service.
 
 ## Configuration
 
@@ -14,4 +14,4 @@ This adapter supports the following configuration settings:
 - `max_retries`: The maximum number of times to retry failed attempts to send data to the server.
 - `retry_interval_ms`: The interval between subsequent retry attempts, in milliseconds
 
-This adapter supports [config overrides](../../../docs/tutorials/config-overrides.md). The override filename is `grpc_cloud_adapter_config.json`, and the default config is located at `res/grpc_cloud_adapter_config.default.json`.
+This adapter supports [config overrides](../../../docs/tutorials/config-overrides.md). The override filename is `grpc_mapping_adapter_config.json`, and the default config is located at `res/grpc_mapping_adapter_config.default.json`.

--- a/adapters/mapping/grpc_mapping_adapter/README.md
+++ b/adapters/mapping/grpc_mapping_adapter/README.md
@@ -1,0 +1,17 @@
+# gRPC Cloud Adapter
+
+The gRPC Cloud Adapter is intended to function as a "standard cloud adapter", enabling integration with other services that implement the appropriate APIs. This reduces the need for custom adapter implementations and facilitates integration with non-rust solutions for other parts of the vehicle system. This library contains an implementation of the `CloudAdapter` trait from the contracts.
+
+## Contract
+
+This adapter utilizes a gRPC client for the `CloudConnector` service in the [cloud connector v1 protobuf description](../../../interfaces/cloud_connector/v1/cloud_connector.proto). To integrate a cloud connector with this adapter, you will need to implement a gRPC server for this service. Samples can be found in the [Ibeji Example Applications Repository](https://github.com/eclipse-ibeji/ibeji-example-applications/tree/main/cloud_connectors/).
+
+## Configuration
+
+This adapter supports the following configuration settings:
+
+- `target_uri`: The URI of the server to call.
+- `max_retries`: The maximum number of times to retry failed attempts to send data to the server.
+- `retry_interval_ms`: The interval between subsequent retry attempts, in milliseconds
+
+This adapter supports [config overrides](../../../docs/tutorials/config-overrides.md). The override filename is `grpc_cloud_adapter_config.json`, and the default config is located at `res/grpc_cloud_adapter_config.default.json`.

--- a/adapters/mapping/grpc_mapping_adapter/README.md
+++ b/adapters/mapping/grpc_mapping_adapter/README.md
@@ -1,6 +1,6 @@
 # gRPC Mapping Adapter
 
-The gRPC Mapping Adapter is intended to function as a "standard mapping adapter", enabling integration with other services that implement the appropriate APIs. This reduces the need for custom adapter implementations and facilitates integration with non-rust solutions for other parts of the vehicle system. This library contains an implementation of the `MappingAdapter` trait from the contracts.
+The gRPC Mapping Adapter is intended to function as a "standard mapping adapter", enabling integration with other services that implement the appropriate APIs. This reduces the need for custom adapter implementations and facilitates integration with non-Rust solutions for other parts of the vehicle system. This library contains an implementation of the `MappingAdapter` trait from the contracts.
 
 ## Contract
 
@@ -11,7 +11,7 @@ This adapter utilizes a gRPC client for the `MappingService` in the [mapping ser
 This adapter supports the following configuration settings:
 
 - `target_uri`: The URI of the server to call.
-- `max_retries`: The maximum number of times to retry failed attempts to send data to the server.
+- `max_retries`: The maximum number of retry attempts when sending data to the server.
 - `retry_interval_ms`: The interval between subsequent retry attempts, in milliseconds
 
 This adapter supports [config overrides](../../../docs/tutorials/config-overrides.md). The override filename is `grpc_mapping_adapter_config.json`, and the default config is located at `res/grpc_mapping_adapter_config.default.json`.

--- a/adapters/mapping/grpc_mapping_adapter/build.rs
+++ b/adapters/mapping/grpc_mapping_adapter/build.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use freyja_build_common::copy_config;
+
+const CONFIG_FILE_STEM: &str = "grpc_mapping_adapter_config";
+
+fn main() {
+    copy_config(CONFIG_FILE_STEM);
+}

--- a/adapters/mapping/grpc_mapping_adapter/res/grpc_mapping_adapter_config.default.json
+++ b/adapters/mapping/grpc_mapping_adapter/res/grpc_mapping_adapter_config.default.json
@@ -1,0 +1,5 @@
+{
+    "target_uri": "http://0.0.0.0:5176",
+    "max_retries": 20,
+    "retry_interval_ms": 10000
+}

--- a/adapters/mapping/grpc_mapping_adapter/res/grpc_mapping_adapter_config.default.json
+++ b/adapters/mapping/grpc_mapping_adapter/res/grpc_mapping_adapter_config.default.json
@@ -1,5 +1,5 @@
 {
-    "target_uri": "http://0.0.0.0:5176",
-    "max_retries": 20,
+    "target_uri": "http://127.0.0.1:8888",
+    "max_retries": 5,
     "retry_interval_ms": 10000
 }

--- a/adapters/mapping/grpc_mapping_adapter/src/config.rs
+++ b/adapters/mapping/grpc_mapping_adapter/src/config.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use serde::{Deserialize, Serialize};
+
+/// Config for the GRPCMappingAdapter
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Config {
+    /// The target uri for the gRPC server
+    pub target_uri: String,
+
+    /// Max retries for contacting the server
+    pub max_retries: u32,
+
+    /// Retry interval in milliseconds
+    pub retry_interval_ms: u64,
+}

--- a/adapters/mapping/grpc_mapping_adapter/src/grpc_mapping_adapter.rs
+++ b/adapters/mapping/grpc_mapping_adapter/src/grpc_mapping_adapter.rs
@@ -10,11 +10,18 @@ use tonic::transport::Channel;
 
 use freyja_build_common::config_file_stem;
 use freyja_common::{
-    config_utils, conversion::Conversion, digital_twin_map_entry::DigitalTwinMapEntry, mapping_adapter::{CheckForWorkRequest, CheckForWorkResponse, GetMappingRequest, GetMappingResponse, MappingAdapter, MappingAdapterError}, out_dir, retry_utils::execute_with_retry
+    config_utils,
+    conversion::Conversion,
+    digital_twin_map_entry::DigitalTwinMapEntry,
+    mapping_adapter::{
+        CheckForWorkRequest, CheckForWorkResponse, GetMappingRequest, GetMappingResponse,
+        MappingAdapter, MappingAdapterError,
+    },
+    out_dir,
+    retry_utils::execute_with_retry,
 };
 use mapping_service_proto::v1::{
-    mapping_service_client::MappingServiceClient,
-    CheckForWorkRequest as ProtoCheckForWorkRequest,
+    mapping_service_client::MappingServiceClient, CheckForWorkRequest as ProtoCheckForWorkRequest,
     GetMappingRequest as ProtoGetMappingRequest,
 };
 
@@ -91,7 +98,7 @@ impl MappingAdapter for GRPCMappingAdapter {
 
         Ok(result)
     }
-    
+
     /// Gets the mapping from the mapping service
     /// Returns the values that are configured to exist for the current internal count
     async fn get_mapping(
@@ -126,19 +133,22 @@ impl MappingAdapter for GRPCMappingAdapter {
                 .mapping
                 .into_iter()
                 .map(|(k, v)| {
-                    (k, DigitalTwinMapEntry {
-                        source: v.source,
-                        target: v.target,
-                        interval_ms: v.interval_ms,
-                        emit_on_change: v.emit_on_change,
-                        conversion: match v.conversion {
-                            Some(c) => Conversion::Linear {
-                                mul: c.mul,
-                                offset: c.offset,
+                    (
+                        k,
+                        DigitalTwinMapEntry {
+                            source: v.source,
+                            target: v.target,
+                            interval_ms: v.interval_ms,
+                            emit_on_change: v.emit_on_change,
+                            conversion: match v.conversion {
+                                Some(c) => Conversion::Linear {
+                                    mul: c.mul,
+                                    offset: c.offset,
+                                },
+                                None => Conversion::None,
                             },
-                            None => Conversion::None,
-                        }
-                    })
+                        },
+                    )
                 })
                 .collect(),
         };

--- a/adapters/mapping/grpc_mapping_adapter/src/grpc_mapping_adapter.rs
+++ b/adapters/mapping/grpc_mapping_adapter/src/grpc_mapping_adapter.rs
@@ -1,0 +1,252 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use log::debug;
+use tonic::transport::Channel;
+
+use freyja_build_common::config_file_stem;
+use freyja_common::{
+    config_utils, conversion::Conversion, digital_twin_map_entry::DigitalTwinMapEntry, mapping_adapter::{CheckForWorkRequest, CheckForWorkResponse, GetMappingRequest, GetMappingResponse, MappingAdapter, MappingAdapterError}, out_dir, retry_utils::execute_with_retry
+};
+use mapping_service_proto::v1::{
+    mapping_service_client::MappingServiceClient,
+    CheckForWorkRequest as ProtoCheckForWorkRequest,
+    GetMappingRequest as ProtoGetMappingRequest,
+};
+
+use crate::config::Config;
+
+/// A "standard" mapping adapter which communicates over gRPC
+pub struct GRPCMappingAdapter {
+    // Adapter config
+    config: Config,
+
+    // The gRPC client
+    client: MappingServiceClient<Channel>,
+}
+
+#[async_trait]
+impl MappingAdapter for GRPCMappingAdapter {
+    /// Creates a new instance of a CloudAdapter with default settings
+    fn create_new() -> Result<Self, MappingAdapterError> {
+        let config: Config = config_utils::read_from_files(
+            config_file_stem!(),
+            config_utils::JSON_EXT,
+            out_dir!(),
+            MappingAdapterError::io,
+            MappingAdapterError::deserialize,
+        )?;
+
+        let client = futures::executor::block_on(async {
+            execute_with_retry(
+                config.max_retries,
+                Duration::from_millis(config.retry_interval_ms),
+                || MappingServiceClient::connect(config.target_uri.clone()),
+                Some("Mapping adapter initial connection".into()),
+            )
+            .await
+            .map_err(MappingAdapterError::communication)
+        })?;
+
+        Ok(Self { config, client })
+    }
+
+    /// Checks for any additional work that the mapping service requires.
+    /// For example, the cloud digital twin has changed and a new mapping needs to be generated
+    /// Increments the internal counter and returns true if this would affect the result of get_mapping compared to the previous call
+    async fn check_for_work(
+        &self,
+        _request: CheckForWorkRequest,
+    ) -> Result<CheckForWorkResponse, MappingAdapterError> {
+        debug!("Received check for work request");
+
+        let request = ProtoCheckForWorkRequest {};
+
+        let response = execute_with_retry(
+            self.config.max_retries,
+            Duration::from_millis(self.config.retry_interval_ms),
+            || async {
+                let request = tonic::Request::new(request.clone());
+                self.client
+                    .clone()
+                    .check_for_work(request)
+                    .await
+                    .map_err(MappingAdapterError::communication)
+            },
+            Some(String::from("Mapping adapter check for work request")),
+        )
+        .await
+        .map_err(MappingAdapterError::communication)?
+        .into_inner();
+
+        debug!("Check for work response: {response:?}");
+
+        let result = CheckForWorkResponse {
+            has_work: response.has_work,
+        };
+
+        Ok(result)
+    }
+    
+    /// Gets the mapping from the mapping service
+    /// Returns the values that are configured to exist for the current internal count
+    async fn get_mapping(
+        &self,
+        _request: GetMappingRequest,
+    ) -> Result<GetMappingResponse, MappingAdapterError> {
+        debug!("Received get mapping request");
+
+        let request = ProtoGetMappingRequest {};
+
+        let response = execute_with_retry(
+            self.config.max_retries,
+            Duration::from_millis(self.config.retry_interval_ms),
+            || async {
+                let request = tonic::Request::new(request.clone());
+                self.client
+                    .clone()
+                    .get_mapping(request)
+                    .await
+                    .map_err(MappingAdapterError::communication)
+            },
+            Some(String::from("Mapping adapter get mapping request")),
+        )
+        .await
+        .map_err(MappingAdapterError::communication)?
+        .into_inner();
+
+        debug!("Get mapping response: {response:?}");
+
+        let result = GetMappingResponse {
+            map: response
+                .mapping
+                .into_iter()
+                .map(|(k, v)| {
+                    (k, DigitalTwinMapEntry {
+                        source: v.source,
+                        target: v.target,
+                        interval_ms: v.interval_ms,
+                        emit_on_change: v.emit_on_change,
+                        conversion: match v.conversion {
+                            Some(c) => Conversion::Linear {
+                                mul: c.mul,
+                                offset: c.offset,
+                            },
+                            None => Conversion::None,
+                        }
+                    })
+                })
+                .collect(),
+        };
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod grpc_mapping_adapter_tests {
+    use super::*;
+
+    /// The tests below uses Unix sockets to create a channel between a gRPC client and a gRPC server.
+    /// Unix sockets are more ideal than using TCP/IP sockets since Rust tests will run in parallel
+    /// so you would need to set an arbitrary port per test for TCP/IP sockets.
+    #[cfg(unix)]
+    mod unix_tests {
+        use super::*;
+
+        use std::sync::Arc;
+
+        use mapping_service_proto::v1::{
+            mapping_service_server::{MappingService, MappingServiceServer},
+            CheckForWorkResponse as ProtoCheckForWorkResponse,
+            GetMappingResponse as ProtoGetMappingResponse,
+        };
+        use tempfile::TempPath;
+        use tokio::net::{UnixListener, UnixStream};
+        use tokio_stream::wrappers::UnixListenerStream;
+        use tonic::{
+            transport::{Channel, Endpoint, Server, Uri},
+            Request, Response, Status,
+        };
+        use tower::service_fn;
+
+        pub struct MockMappingService {}
+
+        #[tonic::async_trait]
+        impl MappingService for MockMappingService {
+            async fn check_for_work(
+                &self,
+                _request: Request<ProtoCheckForWorkRequest>,
+            ) -> Result<Response<ProtoCheckForWorkResponse>, Status> {
+                let response = ProtoCheckForWorkResponse::default();
+                Ok(Response::new(response))
+            }
+
+            async fn get_mapping(
+                &self,
+                _request: Request<ProtoGetMappingRequest>,
+            ) -> Result<Response<ProtoGetMappingResponse>, Status> {
+                let response = ProtoGetMappingResponse::default();
+                Ok(Response::new(response))
+            }
+        }
+
+        async fn create_test_grpc_client(
+            bind_path: Arc<TempPath>,
+        ) -> MappingServiceClient<Channel> {
+            let channel = Endpoint::try_from("http://URI_IGNORED") // Devskim: ignore DS137138
+                .unwrap()
+                .connect_with_connector(service_fn(move |_: Uri| {
+                    let bind_path = bind_path.clone();
+                    async move { UnixStream::connect(bind_path.as_ref()).await }
+                }))
+                .await
+                .unwrap();
+
+            MappingServiceClient::new(channel)
+        }
+
+        async fn run_test_grpc_server(uds_stream: UnixListenerStream) {
+            let mock_azure_connector = MockMappingService {};
+            Server::builder()
+                .add_service(MappingServiceServer::new(mock_azure_connector))
+                .serve_with_incoming(uds_stream)
+                .await
+                .unwrap();
+        }
+
+        #[tokio::test]
+        async fn send_request_to_provider() {
+            // Create the Unix Socket
+            let bind_path = Arc::new(tempfile::NamedTempFile::new().unwrap().into_temp_path());
+            let uds = match UnixListener::bind(bind_path.as_ref()) {
+                Ok(unix_listener) => unix_listener,
+                Err(_) => {
+                    std::fs::remove_file(bind_path.as_ref()).unwrap();
+                    UnixListener::bind(bind_path.as_ref()).unwrap()
+                }
+            };
+            let uds_stream = UnixListenerStream::new(uds);
+
+            let request_future = async {
+                let mut client = create_test_grpc_client(bind_path.clone()).await;
+
+                let request = ProtoGetMappingRequest::default();
+
+                let request = tonic::Request::new(request);
+                assert!(client.get_mapping(request).await.is_ok())
+            };
+
+            tokio::select! {
+                _ = run_test_grpc_server(uds_stream) => (),
+                _ = request_future => ()
+            }
+
+            std::fs::remove_file(bind_path.as_ref()).unwrap();
+        }
+    }
+}

--- a/adapters/mapping/grpc_mapping_adapter/src/lib.rs
+++ b/adapters/mapping/grpc_mapping_adapter/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+mod config;
+pub mod grpc_mapping_adapter;

--- a/adapters/mapping/in_memory_mock_mapping_adapter/src/in_memory_mock_mapping_adapter.rs
+++ b/adapters/mapping/in_memory_mock_mapping_adapter/src/in_memory_mock_mapping_adapter.rs
@@ -97,7 +97,7 @@ mod in_memory_mock_mapping_adapter_tests {
 
     use super::*;
 
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
 
     use freyja_common::{conversion::Conversion, digital_twin_map_entry::DigitalTwinMapEntry};
 
@@ -236,16 +236,5 @@ mod in_memory_mock_mapping_adapter_tests {
             assert!(mapping.iter().any(|p| *p.0 == "delayed-activation"));
             assert!(!mapping.iter().any(|p| *p.0 == "not-always-active"));
         }
-    }
-
-    #[tokio::test]
-    async fn send_inventory_is_ok() {
-        let uut = InMemoryMockMappingAdapter::create_new().unwrap();
-        assert!(uut
-            .send_inventory(SendInventoryRequest {
-                inventory: HashSet::new()
-            })
-            .await
-            .is_ok());
     }
 }

--- a/adapters/mapping/mock_mapping_service_adapter/src/mock_mapping_service_adapter.rs
+++ b/adapters/mapping/mock_mapping_service_adapter/src/mock_mapping_service_adapter.rs
@@ -81,29 +81,6 @@ impl MappingAdapter for MockMappingServiceAdapter {
         .map_err(MappingAdapterError::deserialize)
     }
 
-    /// Sends the provider inventory to the mapping service
-    ///
-    /// # Arguments
-    ///
-    /// - `inventory`: the providers to send
-    async fn send_inventory(
-        &self,
-        inventory: SendInventoryRequest,
-    ) -> Result<SendInventoryResponse, MappingAdapterError> {
-        let target = format!("{}/inventory", self.base_url);
-        self.client
-            .post(&target)
-            .json(&inventory)
-            .send()
-            .await
-            .map_err(MappingAdapterError::communication)?
-            .error_for_status()
-            .map_err(MappingAdapterError::communication)?
-            .json::<SendInventoryResponse>()
-            .await
-            .map_err(MappingAdapterError::deserialize)
-    }
-
     /// Gets the mapping from the mapping service
     /// Returns the values that are configured to exist for the current internal count
     async fn get_mapping(

--- a/common/src/mapping_adapter.rs
+++ b/common/src/mapping_adapter.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 // SPDX-License-Identifier: MIT
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -28,18 +28,6 @@ pub trait MappingAdapter {
         request: CheckForWorkRequest,
     ) -> Result<CheckForWorkResponse, MappingAdapterError>;
 
-    /// Sends the provider inventory to the mapping service
-    ///
-    /// # Arguments
-    ///
-    /// - `inventory`: the request to send
-    async fn send_inventory(
-        &self,
-        _inventory: SendInventoryRequest,
-    ) -> Result<SendInventoryResponse, MappingAdapterError> {
-        Ok(SendInventoryResponse {})
-    }
-
     /// Gets the mapping from the mapping service
     ///
     /// # Arguments
@@ -61,16 +49,6 @@ pub struct CheckForWorkResponse {
     /// Whether or not there is work for the caller
     pub has_work: bool,
 }
-
-/// A request for sending inventory
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SendInventoryRequest {
-    pub inventory: HashSet<String>,
-}
-
-/// A response to sending inventory
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SendInventoryResponse {}
 
 /// A request for a mapping
 #[derive(Debug, Serialize, Deserialize)]

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -114,7 +114,6 @@ Freyja communicates with a mapping service via the `MappingAdapter` trait to get
 
 - `create_new`: Serves as an integration point for the core Freyja components. This function will be called by the `freyja_main` function to create an instance of your adapter.
 - `check_for_work`: Because mappings returned from the `get_mapping` API can potentially be large, this method is used to first poll for changes before calling that API. If the result is false, then the cartographer will not invoke the `get_mapping` API until it polls again.
-- `send_inventory`: This API is currently unused. It is reserved for potential future use, but may also be removed. A default empty implementation is provided for convenience so that this function may be omitted from your trait implementation. It is also safe to use the `unimplemented!()` macro since this function will not be called.
 - `get_mapping`: Returns mapping information that will be used by Freyja's emitter
 
 For more information about the mapping service and how this interface is used, see the [Mapping Service](#mapping-service) section.

--- a/freyja/src/cartographer.rs
+++ b/freyja/src/cartographer.rs
@@ -238,8 +238,7 @@ mod cartographer_tests {
         digital_twin_map_entry::DigitalTwinMapEntry,
         entity::{Entity, EntityEndpoint},
         mapping_adapter::{
-            CheckForWorkResponse, GetMappingResponse, MappingAdapterError, SendInventoryRequest,
-            SendInventoryResponse,
+            CheckForWorkResponse, GetMappingResponse, MappingAdapterError,
         },
         service_discovery_adapter_selector::ServiceDiscoveryAdapterSelector,
     };
@@ -273,11 +272,6 @@ mod cartographer_tests {
                 &self,
                 request: CheckForWorkRequest,
             ) -> Result<CheckForWorkResponse, MappingAdapterError>;
-
-            async fn send_inventory(
-                &self,
-                inventory: SendInventoryRequest,
-            ) -> Result<SendInventoryResponse, MappingAdapterError>;
 
             async fn get_mapping(
                 &self,

--- a/freyja/src/cartographer.rs
+++ b/freyja/src/cartographer.rs
@@ -237,9 +237,7 @@ mod cartographer_tests {
         digital_twin_adapter::{DigitalTwinAdapterError, FindByIdResponse},
         digital_twin_map_entry::DigitalTwinMapEntry,
         entity::{Entity, EntityEndpoint},
-        mapping_adapter::{
-            CheckForWorkResponse, GetMappingResponse, MappingAdapterError,
-        },
+        mapping_adapter::{CheckForWorkResponse, GetMappingResponse, MappingAdapterError},
         service_discovery_adapter_selector::ServiceDiscoveryAdapterSelector,
     };
 

--- a/interfaces/mapping_service/v1/mapping_service.proto
+++ b/interfaces/mapping_service/v1/mapping_service.proto
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+syntax = "proto3";
+
+package mapping_service;
+
+service MappingService {
+    rpc CheckForWork (CheckForWorkRequest) returns (CheckForWorkResponse);
+    rpc GetMapping (GetMappingRequest) returns (GetMappingResponse);
+}
+
+message CheckForWorkRequest {
+}
+
+message CheckForWorkResponse {
+    bool has_work = 1;
+}
+
+message GetMappingRequest {
+}
+
+message GetMappingResponse {
+    map<string, MapEntry> mapping = 1;
+}
+
+message MapEntry {
+    string source = 1;
+    map<string, string> target = 2;
+    uint64 interval_ms = 3;
+    LinearConversion conversion = 4;
+    bool emit_on_change = 5;
+}
+
+message LinearConversion {
+    float mul = 1;
+    float offset = 2;
+}

--- a/mocks/mock_mapping_service/src/main.rs
+++ b/mocks/mock_mapping_service/src/main.rs
@@ -25,9 +25,7 @@ use freyja_build_common::config_file_stem;
 use freyja_common::{
     cmd_utils::{get_log_level, parse_args},
     config_utils,
-    mapping_adapter::{
-        CheckForWorkResponse, GetMappingResponse,
-    },
+    mapping_adapter::{CheckForWorkResponse, GetMappingResponse},
     ok, out_dir,
 };
 

--- a/mocks/mock_mapping_service/src/main.rs
+++ b/mocks/mock_mapping_service/src/main.rs
@@ -13,8 +13,8 @@ use std::{
 use axum::{
     extract::State,
     response::{IntoResponse, Response},
-    routing::{get, post},
-    Json, Router,
+    routing::get,
+    Router,
 };
 use env_logger::Target;
 use log::{info, LevelFilter};
@@ -26,7 +26,7 @@ use freyja_common::{
     cmd_utils::{get_log_level, parse_args},
     config_utils,
     mapping_adapter::{
-        CheckForWorkResponse, GetMappingResponse, SendInventoryRequest, SendInventoryResponse,
+        CheckForWorkResponse, GetMappingResponse,
     },
     ok, out_dir,
 };
@@ -113,7 +113,6 @@ async fn main() {
     // HTTP server setup
     let app = Router::new()
         .route("/work", get(get_work))
-        .route("/inventory", post(send_inventory))
         .route("/mapping", get(get_mapping))
         .with_state(state);
 
@@ -133,14 +132,6 @@ async fn get_work(State(state): State<Arc<Mutex<MappingState>>>) -> Response {
     } else {
         ok!(CheckForWorkResponse { has_work: false })
     }
-}
-
-async fn send_inventory(
-    State(_state): State<Arc<Mutex<MappingState>>>,
-    Json(body): Json<SendInventoryRequest>,
-) -> Response {
-    info!("Got {} items in body", body.inventory.len());
-    ok!(SendInventoryResponse {})
 }
 
 async fn get_mapping(State(state): State<Arc<Mutex<MappingState>>>) -> Response {

--- a/proto/mapping_service/Cargo.toml
+++ b/proto/mapping_service/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
+freyja-common = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 tonic = { workspace = true }

--- a/proto/mapping_service/Cargo.toml
+++ b/proto/mapping_service/Cargo.toml
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "mapping-service-proto"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+prost = { workspace = true }
+prost-types = { workspace = true }
+tonic = { workspace = true }
+
+[build-dependencies]
+tonic-build = { workspace = true }

--- a/proto/mapping_service/build.rs
+++ b/proto/mapping_service/build.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure().compile(
+        &["../../interfaces/mapping_service/v1/mapping_service.proto"],
+        &["../../interfaces/mapping_service/v1/"],
+    )?;
+
+    Ok(())
+}

--- a/proto/mapping_service/src/lib.rs
+++ b/proto/mapping_service/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+// Re-export this library so consumers have access to the types used in generation
+pub use prost_types;
+
+pub mod v1 {
+    tonic::include_proto!("mapping_service");
+}

--- a/proto/mapping_service/src/lib.rs
+++ b/proto/mapping_service/src/lib.rs
@@ -6,5 +6,63 @@
 pub use prost_types;
 
 pub mod v1 {
+    use freyja_common::{conversion::Conversion, digital_twin_map_entry::DigitalTwinMapEntry};
+
     tonic::include_proto!("mapping_service");
+
+    impl From<freyja_common::mapping_adapter::CheckForWorkRequest> for CheckForWorkRequest {
+        fn from(_value: freyja_common::mapping_adapter::CheckForWorkRequest) -> Self {
+            Self {}
+        }
+    }
+
+    impl From<CheckForWorkResponse> for freyja_common::mapping_adapter::CheckForWorkResponse {
+        fn from(value: CheckForWorkResponse) -> Self {
+            Self {
+                has_work: value.has_work,
+            }
+        }
+    }
+
+    impl From<freyja_common::mapping_adapter::GetMappingRequest> for GetMappingRequest {
+        fn from(_value: freyja_common::mapping_adapter::GetMappingRequest) -> Self {
+            Self {}
+        }
+    }
+
+    impl From<GetMappingResponse> for freyja_common::mapping_adapter::GetMappingResponse {
+        fn from(value: GetMappingResponse) -> Self {
+            Self {
+                map: value
+                    .mapping
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl From<MapEntry> for DigitalTwinMapEntry {
+        fn from(value: MapEntry) -> Self {
+            Self {
+                source: value.source,
+                target: value.target,
+                interval_ms: value.interval_ms,
+                emit_on_change: value.emit_on_change,
+                conversion: value
+                    .conversion
+                    .map(|c| c.into())
+                    .unwrap_or(Conversion::None),
+            }
+        }
+    }
+
+    impl From<LinearConversion> for Conversion {
+        fn from(value: LinearConversion) -> Self {
+            Self::Linear {
+                mul: value.mul,
+                offset: value.offset,
+            }
+        }
+    }
 }


### PR DESCRIPTION
Implements the standard mapping adapter. This PR also officially removes the unused `send_inventory` API.

Fixes #125 