### PR TITLE
Target specific versions for remote protobuf files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "freyja-build-common",
  "prost",
  "prost-types",
+ "proto-common",
  "serde",
  "tonic",
 ]
@@ -1510,6 +1511,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "proto-common"
+version = "0.1.0"
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1706,7 @@ dependencies = [
  "freyja-build-common",
  "prost",
  "prost-types",
+ "proto-common",
  "tonic",
 ]
 
@@ -1751,6 +1757,7 @@ dependencies = [
  "freyja-build-common",
  "prost",
  "prost-types",
+ "proto-common",
  "tonic",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "mocks/mock_mapping_service",
   "proc_macros",
   "proto/cloud_connector",
+  "proto/common",
   "proto/core_protobuf_data_access",
   "proto/mapping_service",
   "proto/samples_protobuf_data_access",
@@ -53,6 +54,7 @@ mapping-service-proto = { path = "proto/mapping_service" }
 mock-digital-twin = { path = "mocks/mock_digital_twin" }
 mqtt-data-adapter = { path = "adapters/data/mqtt_data_adapter" }
 proc-macros = { path = "proc_macros" }
+proto-common = { path = "proto/common" }
 sample-grpc-data-adapter = { path = "adapters/data/sample_grpc_data_adapter" }
 samples-protobuf-data-access = { path = "proto/samples_protobuf_data_access" }
 service_discovery_proto = { path = "proto/service_discovery_proto" }

--- a/proto/common/Cargo.toml
+++ b/proto/common/Cargo.toml
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+# SPDX-License-Identifier: MIT
+
+[package]
+name = "proto-common"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]

--- a/proto/common/src/lib.rs
+++ b/proto/common/src/lib.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+// This module contains constants related to remote protobuf files as well as helpers for referencing them.
+
+pub const GITHUB_BASE_URL: &str = "https://raw.githubusercontent.com";
+
+pub mod ibeji {
+    pub const REPO_NAME: &str = "eclipse-ibeji/ibeji";
+    pub const VERSION: &str = "0.1.1";
+
+    pub mod interfaces {
+        pub const INVEHICLE_DIGITAL_TWIN_INTERFACE: &str = "interfaces/invehicle_digital_twin/v1/invehicle_digital_twin.proto";
+        pub const MANAGED_SUBSCRIBE_INTERFACE: &str = "interfaces/module/managed_subscribe/v1/managed_subscribe.proto";
+        pub const SAMPLE_CONSUMER_INTERFACE: &str = "samples/interfaces/sample_grpc/v1/digital_twin_consumer.proto";
+        pub const SAMPLE_PROVIDER_INTERFACE: &str = "samples/interfaces/sample_grpc/v1/digital_twin_provider.proto";
+    }
+}
+
+pub mod chariott {
+    pub const REPO_NAME: &str = "eclipse-chariott/chariott";
+    pub const VERSION: &str = "0.2.1";
+
+    pub mod interfaces {
+        pub const SERVICE_REGISTRY_INTERFACE: &str = "service_discovery/proto/core/v1/service_registry.proto";
+    }
+}
+
+/// Macro that simplifies the construction of URLs for remote protobuf interfaces.
+/// 
+/// # Arguments
+/// - `service`: the service name. Corresponds to one of the submodules of `proto_common`.
+/// - `interface`: the interface name. Corresponds to one of the contants in the `interfaces` sub-module of the `service` module.
+#[macro_export]
+macro_rules! interface_url {
+    ($service:ident, $interface:ident) => {
+        format!(
+            "{}/{}/{}/{}",
+            proto_common::GITHUB_BASE_URL,
+            proto_common::$service::REPO_NAME,
+            proto_common::$service::VERSION,
+            proto_common::$service::interfaces::$interface)
+    };
+}

--- a/proto/common/src/lib.rs
+++ b/proto/common/src/lib.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MIT
 
 // This module contains constants related to remote protobuf files as well as helpers for referencing them.
-// This also help manage interface versions in a central location, which is particularly helpful for Ibeji since
-// the referenced interfaces are split across two different crates.
+// This also helps manage interface versions from a central location, which is particularly helpful for Ibeji since
+// the interfaces are referenced in two different crates.
 
 pub const GITHUB_BASE_URL: &str = "https://raw.githubusercontent.com";
 

--- a/proto/common/src/lib.rs
+++ b/proto/common/src/lib.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: MIT
 
 // This module contains constants related to remote protobuf files as well as helpers for referencing them.
+// This also help manage interface versions in a central location, which is particularly helpful for Ibeji since
+// the referenced interfaces are split across two different crates.
 
 pub const GITHUB_BASE_URL: &str = "https://raw.githubusercontent.com";
 

--- a/proto/common/src/lib.rs
+++ b/proto/common/src/lib.rs
@@ -36,7 +36,7 @@ pub mod chariott {
 ///
 /// # Arguments
 /// - `service`: the service name. Corresponds to one of the submodules of `proto_common`.
-/// - `interface`: the interface name. Corresponds to one of the contants in the `interfaces` sub-module of the `service` module.
+/// - `interface`: the interface name. Corresponds to one of the constants in the `interfaces` sub-module of the `service` module.
 #[macro_export]
 macro_rules! interface_url {
     ($service:ident, $interface:ident) => {

--- a/proto/common/src/lib.rs
+++ b/proto/common/src/lib.rs
@@ -11,10 +11,14 @@ pub mod ibeji {
     pub const VERSION: &str = "0.1.1";
 
     pub mod interfaces {
-        pub const INVEHICLE_DIGITAL_TWIN_INTERFACE: &str = "interfaces/invehicle_digital_twin/v1/invehicle_digital_twin.proto";
-        pub const MANAGED_SUBSCRIBE_INTERFACE: &str = "interfaces/module/managed_subscribe/v1/managed_subscribe.proto";
-        pub const SAMPLE_CONSUMER_INTERFACE: &str = "samples/interfaces/sample_grpc/v1/digital_twin_consumer.proto";
-        pub const SAMPLE_PROVIDER_INTERFACE: &str = "samples/interfaces/sample_grpc/v1/digital_twin_provider.proto";
+        pub const INVEHICLE_DIGITAL_TWIN_INTERFACE: &str =
+            "interfaces/invehicle_digital_twin/v1/invehicle_digital_twin.proto";
+        pub const MANAGED_SUBSCRIBE_INTERFACE: &str =
+            "interfaces/module/managed_subscribe/v1/managed_subscribe.proto";
+        pub const SAMPLE_CONSUMER_INTERFACE: &str =
+            "samples/interfaces/sample_grpc/v1/digital_twin_consumer.proto";
+        pub const SAMPLE_PROVIDER_INTERFACE: &str =
+            "samples/interfaces/sample_grpc/v1/digital_twin_provider.proto";
     }
 }
 
@@ -23,12 +27,13 @@ pub mod chariott {
     pub const VERSION: &str = "0.2.1";
 
     pub mod interfaces {
-        pub const SERVICE_REGISTRY_INTERFACE: &str = "service_discovery/proto/core/v1/service_registry.proto";
+        pub const SERVICE_REGISTRY_INTERFACE: &str =
+            "service_discovery/proto/core/v1/service_registry.proto";
     }
 }
 
 /// Macro that simplifies the construction of URLs for remote protobuf interfaces.
-/// 
+///
 /// # Arguments
 /// - `service`: the service name. Corresponds to one of the submodules of `proto_common`.
 /// - `interface`: the interface name. Corresponds to one of the contants in the `interfaces` sub-module of the `service` module.
@@ -40,6 +45,7 @@ macro_rules! interface_url {
             proto_common::GITHUB_BASE_URL,
             proto_common::$service::REPO_NAME,
             proto_common::$service::VERSION,
-            proto_common::$service::interfaces::$interface)
+            proto_common::$service::interfaces::$interface
+        )
     };
 }

--- a/proto/core_protobuf_data_access/Cargo.toml
+++ b/proto/core_protobuf_data_access/Cargo.toml
@@ -16,3 +16,4 @@ tonic = { workspace = true }
 
 [build-dependencies]
 freyja-build-common = { workspace = true }
+proto-common = { workspace = true }

--- a/proto/core_protobuf_data_access/build.rs
+++ b/proto/core_protobuf_data_access/build.rs
@@ -3,22 +3,18 @@
 // SPDX-License-Identifier: MIT
 
 use freyja_build_common::{compile_remote_proto, SERDE_DERIVE_ATTRIBUTE};
-
-const IBEJI_INTERFACES_BASE_URI: &str =
-    "https://raw.githubusercontent.com/eclipse-ibeji/ibeji/main/interfaces";
+use proto_common::interface_url;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     compile_remote_proto(
-        format!(
-            "{IBEJI_INTERFACES_BASE_URI}/invehicle_digital_twin/v1/invehicle_digital_twin.proto"
-        ),
+        interface_url!(ibeji, INVEHICLE_DIGITAL_TWIN_INTERFACE),
         &[
             ("EndpointInfo", SERDE_DERIVE_ATTRIBUTE),
             ("EntityAccessInfo", SERDE_DERIVE_ATTRIBUTE),
         ],
     )?;
     compile_remote_proto(
-        format!("{IBEJI_INTERFACES_BASE_URI}/module/managed_subscribe/v1/managed_subscribe.proto"),
+        interface_url!(ibeji, MANAGED_SUBSCRIBE_INTERFACE),
         &[
             ("Constraint", SERDE_DERIVE_ATTRIBUTE),
             ("CallbackPayload", SERDE_DERIVE_ATTRIBUTE),

--- a/proto/samples_protobuf_data_access/Cargo.toml
+++ b/proto/samples_protobuf_data_access/Cargo.toml
@@ -15,3 +15,4 @@ tonic = { workspace = true }
 
 [build-dependencies]
 freyja-build-common = { workspace = true }
+proto-common = { workspace = true }

--- a/proto/samples_protobuf_data_access/build.rs
+++ b/proto/samples_protobuf_data_access/build.rs
@@ -6,12 +6,8 @@ use freyja_build_common::compile_remote_proto;
 use proto_common::interface_url;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    compile_remote_proto(
-        interface_url!(ibeji, SAMPLE_CONSUMER_INTERFACE),
-        &[])?;
-    compile_remote_proto(
-        interface_url!(ibeji, SAMPLE_PROVIDER_INTERFACE),
-        &[])?;
+    compile_remote_proto(interface_url!(ibeji, SAMPLE_CONSUMER_INTERFACE), &[])?;
+    compile_remote_proto(interface_url!(ibeji, SAMPLE_PROVIDER_INTERFACE), &[])?;
 
     Ok(())
 }

--- a/proto/samples_protobuf_data_access/build.rs
+++ b/proto/samples_protobuf_data_access/build.rs
@@ -3,17 +3,14 @@
 // SPDX-License-Identifier: MIT
 
 use freyja_build_common::compile_remote_proto;
-
-const IBEJI_SAMPLE_INTERFACES_BASE_URI: &str =
-    "https://raw.githubusercontent.com/eclipse-ibeji/ibeji/main/samples/interfaces";
-const SAMPLE_GRPC_INTERFACE_PATH: &str = "sample_grpc/v1";
+use proto_common::interface_url;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     compile_remote_proto(
-        format!("{IBEJI_SAMPLE_INTERFACES_BASE_URI}/{SAMPLE_GRPC_INTERFACE_PATH}/digital_twin_consumer.proto"),
+        interface_url!(ibeji, SAMPLE_CONSUMER_INTERFACE),
         &[])?;
     compile_remote_proto(
-        format!("{IBEJI_SAMPLE_INTERFACES_BASE_URI}/{SAMPLE_GRPC_INTERFACE_PATH}/digital_twin_provider.proto"),
+        interface_url!(ibeji, SAMPLE_PROVIDER_INTERFACE),
         &[])?;
 
     Ok(())

--- a/proto/service_discovery_proto/Cargo.toml
+++ b/proto/service_discovery_proto/Cargo.toml
@@ -15,3 +15,4 @@ tonic = { workspace = true }
 
 [build-dependencies]
 freyja-build-common = { workspace = true }
+proto-common = { workspace = true }

--- a/proto/service_discovery_proto/build.rs
+++ b/proto/service_discovery_proto/build.rs
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: MIT
 
 use freyja_build_common::compile_remote_proto;
-
-const CHARIOTT_SERVICE_DISCOVERY_INTERFACES_BASE_URI: &str =
-    "https://raw.githubusercontent.com/eclipse-chariott/chariott/main/service_discovery/proto";
+use proto_common::interface_url;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     compile_remote_proto(
-        format!("{CHARIOTT_SERVICE_DISCOVERY_INTERFACES_BASE_URI}/core/v1/service_registry.proto"),
+        interface_url!(chariott, SERVICE_REGISTRY_INTERFACE),
         &[],
     )?;
 

--- a/proto/service_discovery_proto/build.rs
+++ b/proto/service_discovery_proto/build.rs
@@ -6,10 +6,7 @@ use freyja_build_common::compile_remote_proto;
 use proto_common::interface_url;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    compile_remote_proto(
-        interface_url!(chariott, SERVICE_REGISTRY_INTERFACE),
-        &[],
-    )?;
+    compile_remote_proto(interface_url!(chariott, SERVICE_REGISTRY_INTERFACE), &[])?;
 
     Ok(())
 }


### PR DESCRIPTION
Target specific versions for remote protobuf files. Based on anticipated changes in Ibeji targeting main was determined to be unreliable, so a solution was found which reduces the management overhead of trying to maintain the referenced versions. This revises #157