### PR TITLE
Change security policy to Eclipse Foundations'

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,41 +1,10 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V0.0.8 BLOCK -->
+# Security Policy
 
-## Security
+This project implements the Eclipse Foundation Security Policy
 
-Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+* <https://www.eclipse.org/security>
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/opensource/security/definition), please report it to us as described below.
+## Reporting a Vulnerability
 
-## Reporting Security Issues
-
-**Please do not report security vulnerabilities through public GitHub issues.**
-
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/opensource/security/create-report).
-
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/opensource/security/pgpkey).
-
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc).
-
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
-
-* Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-* Full paths of source file(s) related to the manifestation of the issue
-* The location of the affected source code (tag/branch/commit or direct URL)
-* Any configuration required to reproduce the issue
-* Step-by-step instructions to reproduce the issue
-* Proof-of-concept or exploit code (if possible)
-* Impact of the issue, including how an attacker might exploit the issue
-
-This information will help us triage your report more quickly.
-
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/opensource/security/bounty) page for more details about our active programs.
-
-## Preferred Languages
-
-We prefer all communications to be in English.
-
-## Policy
-
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/opensource/security/cvd).
-
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+Please report vulnerabilities to the Eclipse Foundation Security Team at
+<security@eclipse.org>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Choose an applicable closing keyword and provide the related issue(s) -->
Resolves #171 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For legacy reasons the repository had Microsoft's security policy listed. We need to update it to reflect Eclipse Foundation's policy

## Description
<!--- Describe your changes in detail -->
- Use Eclipse foundations' security policy in SECURITY.md
<!--

**PR COMMIT MESSAGE**

Use Conventional Commits to describe the PR commit
https://www.conventionalcommits.org/en/v1.0.0

<type>[optional scope]: </description>

[optional body]

[optional footer(s)]

The commit contains the following structural elements, to communicate intent to
the consumers of your library:

- `fix:` a commit of the type fix patches a bug in your codebase (this correlates
with PATCH in Semantic Versioning).
- `feat:` a commit of the type feat introduces a new feature to the codebase (this
correlates with MINOR in Semantic Versioning).
- `BREAKING CHANGE`: a commit that has a footer BREAKING CHANGE:, or appends a !
after the type/scope, introduces a breaking API change (correlating with MAJOR
in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
- types other than `fix:` and `feat:` are allowed, for example `build:`, `chore:`
, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
- footers other than BREAKING CHANGE: <description> may be provided and follow a
convention similar to git trailer format.

-->
